### PR TITLE
Fix CSP errors and restore icons

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <!-- This is a replit script which adds a banner on the top of the page when opened in development mode outside the replit environment -->
-    <script type="text/javascript" src="https://replit.com/public/js/replit-dev-banner.js"></script>
   </body>
 </html>

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,11 @@ const app = express();
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: false }));
 app.disable("x-powered-by");
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+  }),
+);
 
 const apiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,8 +21,6 @@ export default defineConfig({
       "@": path.resolve(import.meta.dirname, "client", "src"),
       "@shared": path.resolve(import.meta.dirname, "shared"),
       "@assets": path.resolve(import.meta.dirname, "attached_assets"),
-      "lucide-react": path.resolve(import.meta.dirname, "shared", "stubs", "lucide-react.js"),
-      "date-fns": path.resolve(import.meta.dirname, "shared", "stubs", "date-fns.js"),
     },
   },
   root: path.resolve(import.meta.dirname, "client"),


### PR DESCRIPTION
## Summary
- disable Helmet's default CSP to avoid blocking scripts on localhost
- remove replit dev banner from client
- use real `lucide-react` package by dropping alias stubs

## Testing
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847c6035404832aa95a166e7b2d83ac