### PR TITLE
Add debounced search in employer jobs

### DIFF
--- a/client/src/components/employer/EmployerJobs.tsx
+++ b/client/src/components/employer/EmployerJobs.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import React, { useState } from "react";
+import { useDebounce } from "@/hooks/useDebounce";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -64,11 +65,13 @@ export const EmployerJobs: React.FC = () => {
   const queryClient = useQueryClient();
 
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
+  const searchQuery = searchTerm.length >= 3 ? debouncedSearchTerm : "";
   const [filterStatus, setFilterStatus] = useState("active");
   const [sortBy, setSortBy] = useState("latest");
 
   const { data: jobs, isLoading } = useQuery({
-    queryKey: ["/api/employers/jobs", { search: searchTerm, filter: filterStatus, sort: sortBy }],
+    queryKey: ["/api/employers/jobs", { search: searchQuery, filter: filterStatus, sort: sortBy }],
     enabled: !!userProfile?.employer,
   });
 

--- a/client/src/hooks/useDebounce.ts
+++ b/client/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import * as React from "react"
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = React.useState(value)
+
+  React.useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay)
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
## Summary
- add `useDebounce` hook for generic debouncing
- debounce employer job search term and use it in the query key

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68481d2c3d0c832a8878447d5f40b7cb