### PR TITLE
Fix admin auth redirects

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
+import { useEffect } from "react";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "./components/ui/toaster";
@@ -44,7 +45,24 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 function Router() {
-  const { user } = useAuth();
+  const { user, userProfile, loading } = useAuth();
+  const [location, setLocation] = useLocation();
+
+  useEffect(() => {
+    if (!loading && user && userProfile) {
+      if (location === "/") {
+        if (userProfile.role === "admin") {
+          setLocation("/admin/dashboard");
+        } else if (userProfile.role === "employer") {
+          setLocation("/employer/dashboard");
+        } else {
+          setLocation("/dashboard");
+        }
+      } else if (location === "/admin" && userProfile.role === "admin") {
+        setLocation("/admin/dashboard");
+      }
+    }
+  }, [loading, user, userProfile, location, setLocation]);
 
   return (
     <div className="min-h-screen bg-slate-50">

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LoginModal } from "@/components/auth/LoginModal";
 import { Shield, Lock, ArrowLeft } from "lucide-react";
 import { Link, useLocation } from "wouter";
+import { useAuth } from "@/components/auth/AuthProvider";
 import { useToast } from "@/hooks/use-toast";
 import { getAuth } from "firebase/auth";
 import { apiRequest } from "@/lib/queryClient";
@@ -13,6 +14,25 @@ export const Admin: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [, setLocation] = useLocation();
   const { toast } = useToast();
+  const { user, userProfile, loading: authLoading } = useAuth();
+
+  useEffect(() => {
+    if (!authLoading && user && userProfile?.role === "admin") {
+      setLocation("/admin/dashboard");
+    }
+  }, [authLoading, user, userProfile, setLocation]);
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  if (user && userProfile?.role === "admin") {
+    return null;
+  }
 
   // Called after successful Firebase login in LoginModal
   const handleAdminLogin = async () => {


### PR DESCRIPTION
## Summary
- redirect authenticated users to their dashboard based on role
- prevent showing admin login screen if admin is already logged in

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684ad5a11e7c832aab1a1cb988a37954