### PR TITLE
Add demo data with stub routes

### DIFF
--- a/server/demoData.ts
+++ b/server/demoData.ts
@@ -1,0 +1,197 @@
+import {
+  User,
+  Candidate,
+  Employer,
+  JobPost,
+  Application,
+  Shortlist,
+  MatchScore,
+  AdminInviteCode,
+} from "@shared/schema";
+
+const now = new Date();
+
+export const demoUsers: User[] = [
+  {
+    id: 1,
+    firebaseUid: "demo-candidate-uid",
+    email: "candidate@example.com",
+    phone: "555-0001",
+    role: "candidate",
+    name: "Alice Candidate",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    firebaseUid: "demo-employer-uid",
+    email: "employer@example.com",
+    phone: "555-0002",
+    role: "employer",
+    name: "Acme HR",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 3,
+    firebaseUid: "demo-admin-uid",
+    email: "admin@example.com",
+    phone: "555-0003",
+    role: "admin",
+    name: "System Admin",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 4,
+    firebaseUid: "demo-candidate2-uid",
+    email: "jane@example.com",
+    phone: "555-0004",
+    role: "candidate",
+    name: "Jane Doe",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const demoCandidates: Candidate[] = [
+  {
+    id: 1,
+    userId: 1,
+    skills: ["typescript", "react"],
+    languages: ["English"],
+    profileStatus: "verified",
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    userId: 4,
+    dateOfBirth: "1990-01-01",
+    gender: "female",
+    maritalStatus: "single",
+    dependents: 0,
+    address: "456 Side St",
+    emergencyContact: "555-1111",
+    qualifications: [{ degree: "Bachelor", field: "Computer Science" }],
+    experience: [{ company: "Acme", years: 2 }],
+    skills: ["typescript", "react"],
+    languages: ["English"],
+    expectedSalary: 800000,
+    jobCodes: ["DEV001"],
+    documents: [],
+    profileStatus: "verified",
+    deleted: false,
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const demoEmployers: Employer[] = [
+  {
+    id: 1,
+    userId: 2,
+    organizationName: "Acme Inc",
+    registrationNumber: "REG123",
+    businessType: "Software",
+    address: "123 Main St",
+    contactEmail: "employer@example.com",
+    contactPhone: "555-0002",
+    profileStatus: "verified",
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const demoJobPosts: JobPost[] = [
+  {
+    id: 1,
+    employerId: 1,
+    jobCode: "DEV001",
+    title: "Full Stack Developer",
+    description: "Work on our web platform",
+    minQualification: "Bachelors",
+    experienceRequired: "2 years",
+    skills: "typescript,react,node",
+    responsibilities: "Develop and maintain apps",
+    salaryRange: "\u20B96-10 LPA",
+    location: "Remote",
+    vacancy: 1,
+    isActive: true,
+    fulfilled: false,
+    deleted: false,
+    applicationsCount: 0,
+    createdAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    employerId: 1,
+    jobCode: "DEV002",
+    title: "Frontend Developer",
+    description: "Build UI components",
+    minQualification: "Diploma",
+    experienceRequired: "1 year",
+    skills: "javascript,react,css",
+    responsibilities: "Create and maintain web UIs",
+    salaryRange: "\u20B95-7 LPA",
+    location: "Remote",
+    vacancy: 2,
+    isActive: true,
+    fulfilled: false,
+    deleted: false,
+    applicationsCount: 0,
+    createdAt: now,
+    updatedAt: now,
+  },
+];
+
+export const demoApplications: Application[] = [
+  {
+    id: 1,
+    candidateId: 1,
+    jobPostId: 1,
+    status: "applied",
+    appliedAt: now,
+    updatedAt: now,
+  },
+  {
+    id: 2,
+    candidateId: 2,
+    jobPostId: 2,
+    status: "applied",
+    appliedAt: now,
+    updatedAt: now,
+  },
+];
+
+export const demoShortlists: Shortlist[] = [
+  {
+    id: 1,
+    jobPostId: 1,
+    candidateId: 1,
+    matchScore: 85,
+    shortlistedBy: 3,
+    shortlistedAt: now,
+  },
+];
+
+export const demoMatchScores: MatchScore[] = [
+  {
+    id: 1,
+    jobPostId: 1,
+    candidateId: 1,
+    score: 90,
+    factors: { skills: 90, experience: 80 },
+    calculatedAt: now,
+  },
+];
+
+export const demoAdminInviteCodes: AdminInviteCode[] = [
+  {
+    id: 1,
+    code: "INVITE123",
+    used: false,
+    createdAt: now,
+  },
+];

--- a/server/demoRoutes.ts
+++ b/server/demoRoutes.ts
@@ -1,0 +1,62 @@
+import type { Express } from "express";
+import { createServer, type Server } from "http";
+import {
+  demoUsers,
+  demoCandidates,
+  demoEmployers,
+  demoJobPosts,
+  demoApplications,
+  demoShortlists,
+  demoMatchScores,
+  demoAdminInviteCodes,
+} from "./demoData";
+
+export async function registerDemoRoutes(app: Express): Promise<Server> {
+  app.get("/api/users", (_req, res) => {
+    res.json(demoUsers);
+  });
+
+  app.get("/api/candidates", (_req, res) => {
+    res.json(demoCandidates);
+  });
+
+  app.get("/api/employers", (_req, res) => {
+    res.json(demoEmployers);
+  });
+
+  app.get("/api/jobs", (_req, res) => {
+    res.json(demoJobPosts);
+  });
+
+  app.get("/api/applications", (_req, res) => {
+    res.json(demoApplications);
+  });
+
+  app.get("/api/shortlists", (_req, res) => {
+    res.json(demoShortlists);
+  });
+
+  app.get("/api/match-scores", (_req, res) => {
+    res.json(demoMatchScores);
+  });
+
+  app.get("/api/admin/invite-codes", (_req, res) => {
+    res.json(demoAdminInviteCodes);
+  });
+
+  app.get("/api/admin/stats", (_req, res) => {
+    const stats = {
+      candidates: demoCandidates.length,
+      jobs: demoJobPosts.length,
+      matches: demoShortlists.length,
+      matchRate:
+        demoCandidates.length > 0
+          ? Math.round((demoShortlists.length / demoCandidates.length) * 100)
+          : 0,
+    };
+    res.json(stats);
+  });
+
+  const httpServer = createServer(app);
+  return httpServer;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes";
+import { registerDemoRoutes } from "./demoRoutes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
@@ -56,7 +57,8 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  const server = await registerRoutes(app);
+  const useDemo = process.env.DEMO_MODE === "true";
+  const server = useDemo ? await registerDemoRoutes(app) : await registerRoutes(app);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;


### PR DESCRIPTION
## Summary
- provide demo users, candidates, employers and job posts
- export demo route handlers
- allow switching to the stub routes with `DEMO_MODE=true`
- expand stub data to include applications, shortlists, match scores and admin invite codes
- add endpoints to serve the expanded demo data

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684ae7cb0628832ab0517a934f7191b7