### PR TITLE
Wrap console logs behind debug utility

### DIFF
--- a/client/src/components/admin/AdminDashboard.tsx
+++ b/client/src/components/admin/AdminDashboard.tsx
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { MatchingEngine } from "./MatchingEngine";
 import { apiRequest, throwIfResNotOk } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { debugLog } from "@/lib/logger";
 
 export const AdminDashboard: React.FC = () => {
   const { data: stats } = useQuery({
@@ -51,12 +52,12 @@ export const AdminDashboard: React.FC = () => {
 
   const handleExportData = () => {
     // Implement export functionality
-    console.log("Exporting data...");
+    debugLog("Exporting data...");
   };
 
   const handleRunMatching = () => {
     // Implement AI matching
-    console.log("Running AI matching...");
+    debugLog("Running AI matching...");
   };
 
   return (

--- a/client/src/components/admin/AdminSearchPanel.tsx
+++ b/client/src/components/admin/AdminSearchPanel.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Filter, Search, SortAsc, MoreVertical, Eye, Edit, Trash2, CheckCircle, User, Building2, FileText, FlaskConical, Users, Briefcase, MapPin, Calendar } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
+import { debugLog } from "@/lib/logger";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useLocation } from "wouter";
 
@@ -74,13 +75,13 @@ const useAdminSearch = (type: string, query: string, filters: SearchFilters, sor
         });
         
         const url = `${API_BASE_URL}${ENDPOINTS.ADMIN.SEARCH}?${params}`;
-        console.log('Fetching from:', url); // Debug log
+        debugLog('Fetching from:', url);
         
         const response = await apiRequest(url, 'GET');
         const data = await response.json();
         
         // Log the response for debugging
-        console.log('Search response:', data);
+        debugLog('Search response:', data);
         
         if (!response.ok) {
           throw new Error(data.message || data.error || 'Search failed');

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -19,6 +19,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertJobPostSchema } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
+import { debugLog } from "@/lib/logger";
 import { useToast } from "@/hooks/use-toast";
 import { z } from "zod";
 
@@ -99,25 +100,25 @@ export const EmployerJobEdit: React.FC = () => {
   });
 
   const onSubmit = (data: EditJobFormData) => {
-    console.log("onSubmit called with data:", data);
+    debugLog("onSubmit called with data:", data);
     updateJobMutation.mutate(data);
   };
 
   React.useEffect(() => {
     if (form.formState.errors && Object.keys(form.formState.errors).length > 0) {
-      console.log("Form validation errors:", form.formState.errors);
+      debugLog("Form validation errors:", form.formState.errors);
     }
   }, [form.formState.errors]);
 
   React.useEffect(() => {
     if (updateJobMutation.isError) {
-      console.log("Mutation error:", updateJobMutation.error);
+      debugLog("Mutation error:", updateJobMutation.error);
     }
     if (updateJobMutation.isSuccess) {
-      console.log("Mutation success");
+      debugLog("Mutation success");
     }
     if (updateJobMutation.isPending) {
-      console.log("Mutation pending...");
+      debugLog("Mutation pending...");
     }
   }, [updateJobMutation.isError, updateJobMutation.isSuccess, updateJobMutation.isPending, updateJobMutation.error]);
 

--- a/client/src/components/employer/EmployerRegistration.tsx
+++ b/client/src/components/employer/EmployerRegistration.tsx
@@ -9,6 +9,7 @@ import { Building, FileText, Upload, Save, X } from "lucide-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { debugLog } from "@/lib/logger";
 import { useLocation } from "wouter";
 
 interface EmployerFormData {
@@ -58,10 +59,10 @@ export const EmployerRegistration: React.FC = () => {
   const createEmployerMutation = useMutation({
     mutationFn: async (employerData: EmployerFormData) => {
       try {
-        console.log("Submitting employer data:", employerData);
+        debugLog("Submitting employer data:", employerData);
         const response = await apiRequest("/api/employers", "POST", employerData);
         const result = await response.json();
-        console.log("Registration response:", result);
+        debugLog("Registration response:", result);
         return result;
       } catch (error: any) {
         console.error("Registration error:", error);
@@ -79,7 +80,7 @@ export const EmployerRegistration: React.FC = () => {
       }
     },
     onSuccess: (data) => {
-      console.log("Registration successful:", data);
+      debugLog("Registration successful:", data);
       toast({
         title: "Registration successful",
         description: "Your employer profile has been created successfully",

--- a/client/src/lib/logger.ts
+++ b/client/src/lib/logger.ts
@@ -1,0 +1,5 @@
+export const debugLog = (...args: unknown[]) => {
+  if (import.meta.env.DEV) {
+    console.log(...args);
+  }
+};


### PR DESCRIPTION
## Summary
- add simple `debugLog` utility for dev-only logging
- use `debugLog` in Admin components
- use `debugLog` in Employer components

## Testing
- `npm run check` *(fails: cannot find module declarations and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c62cd635c832a9eb37409d590daad