### PR TITLE
Update gitignore for env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ server/public
 vite.config.ts.*
 *.tar.gz
 .env
+.env.*
+!.env.example


### PR DESCRIPTION
## Summary
- prevent committing env secrets by adding `.env.*` to the ignore list

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c63060860832a9182ebae02008d62