### PR TITLE
Add async error handling middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,9 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes/index";
 import { setupVite, serveStatic, log } from "./vite";
+import { errorHandler } from "./middleware/errorHandler";
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -58,13 +59,7 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(errorHandler);
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route

--- a/server/middleware/asyncHandler.ts
+++ b/server/middleware/asyncHandler.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from 'express';
+
+export const asyncHandler = (fn: (...args: any[]) => Promise<any>): RequestHandler => {
+  return function (req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -4,273 +4,194 @@ import { insertShortlistSchema } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
 import { calculateMatchScore } from '../utils/matchingEngine';
 import { exportToExcel, exportToPDF } from '../utils/exportUtils';
+import { asyncHandler } from '../middleware/asyncHandler';
 
 export const adminRouter = Router();
 
-adminRouter.get('/stats', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const stats = await storage.getAdminStats();
-    res.json(stats);
-  } catch (error) {
-    console.error('Admin stats fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch admin stats' });
+adminRouter.get('/stats', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const stats = await storage.getAdminStats();
+  res.json(stats);
+}));
 
-adminRouter.get('/jobs', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobs = await storage.getAllJobPosts();
-    res.json(jobs);
-  } catch (error) {
-    console.error('Jobs fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch jobs' });
+adminRouter.get('/jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobs = await storage.getAllJobPosts();
+  res.json(jobs);
+}));
 
-adminRouter.get('/unverified-employers', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employers = await storage.getUnverifiedEmployers();
-    res.json(employers);
-  } catch (error) {
-    console.error('Unverified employers fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch employers' });
+adminRouter.get('/unverified-employers', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employers = await storage.getUnverifiedEmployers();
+  res.json(employers);
+}));
 
-adminRouter.get('/unverified-candidates', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidates = await storage.getUnverifiedCandidates();
-    res.json(candidates);
-  } catch (error) {
-    console.error('Unverified candidates fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch candidates' });
+adminRouter.get('/unverified-candidates', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidates = await storage.getUnverifiedCandidates();
+  res.json(candidates);
+}));
 
-adminRouter.patch('/employers/:id/verify', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const id = parseInt(req.params.id);
-    const employer = await storage.verifyEmployer(id);
-    res.json(employer);
-  } catch (error) {
-    console.error('Employer verify error:', error);
-    res.status(400).json({ message: 'Failed to verify employer' });
+adminRouter.patch('/employers/:id/verify', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const id = parseInt(req.params.id);
+  const employer = await storage.verifyEmployer(id);
+  res.json(employer);
+}));
 
-adminRouter.patch('/candidates/:id/verify', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const id = parseInt(req.params.id);
-    const candidate = await storage.verifyCandidate(id);
-    res.json(candidate);
-  } catch (error) {
-    console.error('Candidate verify error:', error);
-    res.status(400).json({ message: 'Failed to verify candidate' });
+adminRouter.patch('/candidates/:id/verify', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const id = parseInt(req.params.id);
+  const candidate = await storage.verifyCandidate(id);
+  res.json(candidate);
+}));
 
-adminRouter.delete('/employers/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const id = parseInt(req.params.id);
-    const employer = await storage.softDeleteEmployer(id);
-    res.json(employer);
-  } catch (error) {
-    console.error('Employer delete error:', error);
-    res.status(400).json({ message: 'Failed to delete employer' });
+adminRouter.delete('/employers/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const id = parseInt(req.params.id);
+  const employer = await storage.softDeleteEmployer(id);
+  res.json(employer);
+}));
 
-adminRouter.delete('/candidates/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const id = parseInt(req.params.id);
-    const candidate = await storage.softDeleteCandidate(id);
-    res.json(candidate);
-  } catch (error) {
-    console.error('Candidate delete error:', error);
-    res.status(400).json({ message: 'Failed to delete candidate' });
+adminRouter.delete('/candidates/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const id = parseInt(req.params.id);
+  const candidate = await storage.softDeleteCandidate(id);
+  res.json(candidate);
+}));
 
-adminRouter.delete('/jobs/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const id = parseInt(req.params.id);
-    const job = await storage.softDeleteJobPost(id);
-    res.json(job);
-  } catch (error) {
-    console.error('Job delete error:', error);
-    res.status(400).json({ message: 'Failed to delete job' });
+adminRouter.delete('/jobs/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const id = parseInt(req.params.id);
+  const job = await storage.softDeleteJobPost(id);
+  res.json(job);
+}));
 
-adminRouter.get('/candidates', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidates = await storage.getAllCandidates();
-    res.json(candidates);
-  } catch (error) {
-    console.error('Candidates fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch candidates' });
+adminRouter.get('/candidates', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidates = await storage.getAllCandidates();
+  res.json(candidates);
+}));
 
-adminRouter.get('/jobs/:jobId/matches', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobId = parseInt(req.params.jobId);
-    const job = await storage.getJobPost(jobId);
-    if (!job) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    const candidates = await storage.getAllCandidates();
-    const matches = candidates.map(candidate => ({
-      candidateId: candidate.id,
-      candidate,
-      score: calculateMatchScore(job, candidate),
-      skillsMatch: Array.isArray(candidate.skills)
-        ? (candidate.skills as string[]).map(skill => ({
-            name: skill,
-            matches: Array.isArray(job.skills) ? (job.skills as string[]).includes(skill) : false,
-          }))
-        : [],
-      experienceMatch: true,
-      salaryMatch: true,
-    })).sort((a, b) => b.score - a.score).slice(0, 10);
-    res.json(matches);
-  } catch (error) {
-    console.error('Job matches fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch job matches' });
+adminRouter.get('/jobs/:jobId/matches', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobId = parseInt(req.params.jobId);
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const candidates = await storage.getAllCandidates();
+  const matches = candidates.map(candidate => ({
+    candidateId: candidate.id,
+    candidate,
+    score: calculateMatchScore(job, candidate),
+    skillsMatch: Array.isArray(candidate.skills)
+      ? (candidate.skills as string[]).map(skill => ({
+          name: skill,
+          matches: Array.isArray(job.skills) ? (job.skills as string[]).includes(skill) : false,
+        }))
+      : [],
+    experienceMatch: true,
+    salaryMatch: true,
+  })).sort((a, b) => b.score - a.score).slice(0, 10);
+  res.json(matches);
+}));
 
-adminRouter.get('/candidates/:candidateId/matches', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidateId = parseInt(req.params.candidateId);
-    const candidate = await storage.getCandidate(candidateId);
-    if (!candidate) {
-      return res.status(404).json({ message: 'Candidate not found' });
-    }
-    const jobs = await storage.getAllJobPosts();
-    const matches = jobs.map(job => ({
-      jobId: job.id,
-      job,
-      score: calculateMatchScore(job, candidate),
-    })).sort((a, b) => b.score - a.score).slice(0, 10);
-    res.json(matches);
-  } catch (error) {
-    console.error('Candidate matches fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch candidate matches' });
+adminRouter.get('/candidates/:candidateId/matches', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidateId = parseInt(req.params.candidateId);
+  const candidate = await storage.getCandidate(candidateId);
+  if (!candidate) {
+    return res.status(404).json({ message: 'Candidate not found' });
+  }
+  const jobs = await storage.getAllJobPosts();
+  const matches = jobs.map(job => ({
+    jobId: job.id,
+    job,
+    score: calculateMatchScore(job, candidate),
+  })).sort((a, b) => b.score - a.score).slice(0, 10);
+  res.json(matches);
+}));
 
-adminRouter.post('/shortlist', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const shortlistData = insertShortlistSchema.parse({ ...req.body, shortlistedBy: user.id });
-    const shortlist = await storage.createShortlist(shortlistData);
-    res.json(shortlist);
-  } catch (error) {
-    console.error('Shortlist creation error:', error);
-    res.status(400).json({ message: 'Failed to create shortlist' });
+adminRouter.post('/shortlist', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const shortlistData = insertShortlistSchema.parse({ ...req.body, shortlistedBy: user.id });
+  const shortlist = await storage.createShortlist(shortlistData);
+  res.json(shortlist);
+}));
 
-adminRouter.get('/export/excel', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const data = await storage.getExportData();
-    const buffer = await exportToExcel(data);
-    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    res.setHeader('Content-Disposition', 'attachment; filename=lokaltalent-data.xlsx');
-    res.send(buffer);
-  } catch (error) {
-    console.error('Excel export error:', error);
-    res.status(500).json({ message: 'Failed to export Excel file' });
+adminRouter.get('/export/excel', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const data = await storage.getExportData();
+  const buffer = await exportToExcel(data);
+  res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.setHeader('Content-Disposition', 'attachment; filename=lokaltalent-data.xlsx');
+  res.send(buffer);
+}));
 
-adminRouter.get('/export/pdf', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const data = await storage.getExportData();
-    const buffer = await exportToPDF(data);
-    res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader('Content-Disposition', 'attachment; filename=lokaltalent-report.pdf');
-    res.send(buffer);
-  } catch (error) {
-    console.error('PDF export error:', error);
-    res.status(500).json({ message: 'Failed to export PDF file' });
+adminRouter.get('/export/pdf', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const data = await storage.getExportData();
+  const buffer = await exportToPDF(data);
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', 'attachment; filename=lokaltalent-report.pdf');
+  res.send(buffer);
+}));
 
-adminRouter.post('/login', async (req, res) => {
-  try {
-    const { firebaseToken } = req.body;
-    if (!firebaseToken) {
-      return res.status(400).json({ message: 'Missing Firebase token' });
-    }
-    const decodedToken = await verifyFirebaseToken(firebaseToken);
-    const user = await storage.getUserByFirebaseUid(decodedToken.uid);
-    if (!user || user.role !== 'admin') {
-      return res.status(403).json({ message: 'Access denied: not an admin' });
-    }
-    res.json({ success: true, user: { id: user.id, email: user.email, name: user.name, role: user.role } });
-  } catch (error) {
-    console.error('Admin login error:', error);
-    res.status(401).json({ message: 'Invalid credentials or not an admin' });
+adminRouter.post('/login', asyncHandler(async (req, res) => {
+  const { firebaseToken } = req.body;
+  if (!firebaseToken) {
+    return res.status(400).json({ message: 'Missing Firebase token' });
   }
-});
+  const decodedToken = await verifyFirebaseToken(firebaseToken);
+  const user = await storage.getUserByFirebaseUid(decodedToken.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied: not an admin' });
+  }
+  res.json({ success: true, user: { id: user.id, email: user.email, name: user.name, role: user.role } });
+}));

--- a/server/routes/admin/search.ts
+++ b/server/routes/admin/search.ts
@@ -9,6 +9,7 @@ import {
   employerProfiles
 } from "../../../shared/schema";
 import { createVerifyMiddleware } from "../../utils/auth";
+import { asyncHandler } from "../../middleware/asyncHandler";
 
 // Types for query parameters
 interface SearchParams {
@@ -35,8 +36,7 @@ interface ExtendedSearchParams extends SearchParams {
   useCursor?: boolean;
 }
 
-export const searchHandler = [...searchMiddleware, async (req, res) => {
-  try {
+export const searchHandler = [...searchMiddleware, asyncHandler(async (req, res) => {
     const params = req.query as ExtendedSearchParams;
     const { 
       type, 
@@ -97,11 +97,7 @@ export const searchHandler = [...searchMiddleware, async (req, res) => {
     });
 
     res.json({ results });
-  } catch (error) {
-    console.error('Search error:', error);
-    res.status(500).json({ error: 'Search failed' });
-  }
-}];
+})];
 
 async function searchCandidates(params: SearchParams, q: string, sort: string) {
   const { page = 1, pageSize = 20, cursor } = params;

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -2,48 +2,36 @@ import { Router } from 'express';
 import { storage } from '../storage';
 import { insertUserSchema, type InsertUser } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
+import { asyncHandler } from '../middleware/asyncHandler';
 
 export const authRouter = Router();
 
-authRouter.post('/register', async (req, res) => {
-  try {
-    const userData: InsertUser = insertUserSchema.parse(req.body);
-    const existingUserByUid = await storage.getUserByFirebaseUid(userData.firebaseUid);
-    if (existingUserByUid) {
-      return res.json(existingUserByUid);
-    }
-    const existingUserByEmail = await storage.getUserByEmail(userData.email);
-    if (existingUserByEmail) {
-      return res.status(409).json({ message: 'Email already registered', code: 'EMAIL_EXISTS' });
-    }
-    const user = await storage.createUser(userData);
-    res.json(user);
-  } catch (error: any) {
-    console.error('Registration error:', error);
-    if (error.code === '23505' && error.constraint === 'users_email_unique') {
-      return res.status(409).json({ message: 'Email already registered', code: 'EMAIL_EXISTS' });
-    }
-    res.status(400).json({ message: 'Registration failed' });
+authRouter.post('/register', asyncHandler(async (req, res) => {
+  const userData: InsertUser = insertUserSchema.parse(req.body);
+  const existingUserByUid = await storage.getUserByFirebaseUid(userData.firebaseUid);
+  if (existingUserByUid) {
+    return res.json(existingUserByUid);
   }
-});
+  const existingUserByEmail = await storage.getUserByEmail(userData.email);
+  if (existingUserByEmail) {
+    return res.status(409).json({ message: 'Email already registered', code: 'EMAIL_EXISTS' });
+  }
+  const user = await storage.createUser(userData);
+  res.json(user);
+}));
 
-authRouter.get('/profile', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user) {
-      return res.status(404).json({ message: 'User not found' });
-    }
-    let profileData: any = { ...user };
-    if (user.role === 'candidate') {
-      const candidate = await storage.getCandidateByUserId(user.id);
-      profileData.candidate = candidate;
-    } else if (user.role === 'employer') {
-      const employer = await storage.getEmployerByUserId(user.id);
-      profileData.employer = employer;
-    }
-    res.json(profileData);
-  } catch (error) {
-    console.error('Profile fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch profile' });
+authRouter.get('/profile', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user) {
+    return res.status(404).json({ message: 'User not found' });
   }
-});
+  let profileData: any = { ...user };
+  if (user.role === 'candidate') {
+    const candidate = await storage.getCandidateByUserId(user.id);
+    profileData.candidate = candidate;
+  } else if (user.role === 'employer') {
+    const employer = await storage.getEmployerByUserId(user.id);
+    profileData.employer = employer;
+  }
+  res.json(profileData);
+}));

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -2,124 +2,95 @@ import { Router } from 'express';
 import { storage } from '../storage';
 import { insertCandidateSchema, type InsertCandidate } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
+import { asyncHandler } from '../middleware/asyncHandler';
 
 export const candidatesRouter = Router();
 
-candidatesRouter.get('/profile', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidate = await storage.getCandidateByUserId(user.id);
-    if (!candidate || candidate.deleted) {
-      return res.status(404).json({ message: 'Candidate profile not found' });
-    }
-    if (candidate.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Candidate not verified' });
-    }
-    res.json(candidate);
-  } catch (error) {
-    console.error('Candidate profile fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch candidate profile' });
+candidatesRouter.get('/profile', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidate = await storage.getCandidateByUserId(user.id);
+  if (!candidate || candidate.deleted) {
+    return res.status(404).json({ message: 'Candidate profile not found' });
+  }
+  if (candidate.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Candidate not verified' });
+  }
+  res.json(candidate);
+}));
 
-candidatesRouter.patch('/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidate = await storage.getCandidateByUserId(user.id);
-    if (!candidate || candidate.id !== parseInt(req.params.id)) {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const updatedCandidate = await storage.updateCandidate(candidate.id, req.body);
-    res.json(updatedCandidate);
-  } catch (error) {
-    console.error('Candidate update error:', error);
-    res.status(400).json({ message: 'Failed to update candidate profile' });
+candidatesRouter.patch('/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidate = await storage.getCandidateByUserId(user.id);
+  if (!candidate || candidate.id !== parseInt(req.params.id)) {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const updatedCandidate = await storage.updateCandidate(candidate.id, req.body);
+  res.json(updatedCandidate);
+}));
 
-candidatesRouter.post('/', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidateData: InsertCandidate = insertCandidateSchema.parse({
-      ...req.body,
-      userId: user.id,
-    });
-    const candidate = await storage.createCandidate(candidateData);
-    res.json(candidate);
-  } catch (error) {
-    console.error('Candidate creation error:', error);
-    res.status(400).json({ message: 'Failed to create candidate profile' });
+candidatesRouter.post('/', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidateData: InsertCandidate = insertCandidateSchema.parse({
+    ...req.body,
+    userId: user.id,
+  });
+  const candidate = await storage.createCandidate(candidateData);
+  res.json(candidate);
+}));
 
-candidatesRouter.get('/stats', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidate = await storage.getCandidateByUserId(user.id);
-    if (!candidate || candidate.deleted) {
-      return res.status(404).json({ message: 'Candidate profile not found' });
-    }
-    if (candidate.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Candidate not verified' });
-    }
-    const stats = await storage.getCandidateStats(candidate.id);
-    res.json(stats);
-  } catch (error) {
-    console.error('Stats fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch stats' });
+candidatesRouter.get('/stats', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidate = await storage.getCandidateByUserId(user.id);
+  if (!candidate || candidate.deleted) {
+    return res.status(404).json({ message: 'Candidate profile not found' });
+  }
+  if (candidate.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Candidate not verified' });
+  }
+  const stats = await storage.getCandidateStats(candidate.id);
+  res.json(stats);
+}));
 
-candidatesRouter.get('/recommended-jobs', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidate = await storage.getCandidateByUserId(user.id);
-    if (!candidate || candidate.deleted) {
-      return res.status(404).json({ message: 'Candidate profile not found' });
-    }
-    if (candidate.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Candidate not verified' });
-    }
-    const jobs = await storage.getRecommendedJobs(candidate.id);
-    res.json(jobs);
-  } catch (error) {
-    console.error('Recommended jobs fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch recommended jobs' });
+candidatesRouter.get('/recommended-jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidate = await storage.getCandidateByUserId(user.id);
+  if (!candidate || candidate.deleted) {
+    return res.status(404).json({ message: 'Candidate profile not found' });
+  }
+  if (candidate.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Candidate not verified' });
+  }
+  const jobs = await storage.getRecommendedJobs(candidate.id);
+  res.json(jobs);
+}));
 
-candidatesRouter.get('/applications', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'candidate') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const candidate = await storage.getCandidateByUserId(user.id);
-    if (!candidate || candidate.deleted) {
-      return res.status(404).json({ message: 'Candidate profile not found' });
-    }
-    if (candidate.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Candidate not verified' });
-    }
-    const applications = await storage.getCandidateApplications(candidate.id);
-    res.json(applications);
-  } catch (error) {
-    console.error('Applications fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch applications' });
+candidatesRouter.get('/applications', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'candidate') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const candidate = await storage.getCandidateByUserId(user.id);
+  if (!candidate || candidate.deleted) {
+    return res.status(404).json({ message: 'Candidate profile not found' });
+  }
+  if (candidate.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Candidate not verified' });
+  }
+  const applications = await storage.getCandidateApplications(candidate.id);
+  res.json(applications);
+}));

--- a/server/routes/employers.ts
+++ b/server/routes/employers.ts
@@ -2,199 +2,146 @@ import { Router, Request, Response } from 'express';
 import { storage } from '../storage';
 import { insertEmployerSchema, insertJobPostSchema, type InsertEmployer, type InsertJobPost } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
+import { asyncHandler } from '../middleware/asyncHandler';
 
 export const employersRouter = Router();
 
-employersRouter.post('/', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const existingEmployer = await storage.getEmployerByUserId(user.id);
-    if (existingEmployer) {
-      return res.status(409).json({ message: 'Employer profile already exists', code: 'EMPLOYER_EXISTS' });
-    }
-    const employerData: InsertEmployer = insertEmployerSchema.parse({ ...req.body, userId: user.id });
-    const employer = await storage.createEmployer(employerData);
-    res.json(employer);
-  } catch (error: any) {
-    console.error('Employer creation error:', error);
-    if (error.code === '23505') {
-      return res.status(409).json({ message: 'Employer profile already exists', code: 'EMPLOYER_EXISTS' });
-    }
-    if (error.name === 'ZodError') {
-      return res.status(400).json({ message: 'Invalid data provided', details: error.errors });
-    }
-    res.status(500).json({ message: 'Failed to create employer profile' });
+employersRouter.post('/', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const existingEmployer = await storage.getEmployerByUserId(user.id);
+  if (existingEmployer) {
+    return res.status(409).json({ message: 'Employer profile already exists', code: 'EMPLOYER_EXISTS' });
+  }
+  const employerData: InsertEmployer = insertEmployerSchema.parse({ ...req.body, userId: user.id });
+  const employer = await storage.createEmployer(employerData);
+  res.json(employer);
+}));
 
-employersRouter.get('/stats', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || employer.deleted) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const stats = await storage.getEmployerStats(employer.id);
-    res.json(stats);
-  } catch (error) {
-    console.error('Stats fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch stats' });
+employersRouter.get('/stats', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || employer.deleted) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const stats = await storage.getEmployerStats(employer.id);
+  res.json(stats);
+}));
 
-employersRouter.get('/jobs', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || employer.deleted) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const jobPosts = await storage.getJobPostsByEmployer(employer.id);
-    res.json(jobPosts);
-  } catch (error) {
-    console.error('Job posts fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch job posts' });
+employersRouter.get('/jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || employer.deleted) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const jobPosts = await storage.getJobPostsByEmployer(employer.id);
+  res.json(jobPosts);
+}));
 
-employersRouter.get('/recent-jobs', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const recentJobs = await storage.getActiveUnfulfilledJobsByEmployer(employer.id);
-    res.json(recentJobs.slice(0, 5));
-  } catch (error) {
-    console.error('Recent jobs fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch recent jobs' });
+employersRouter.get('/recent-jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const recentJobs = await storage.getActiveUnfulfilledJobsByEmployer(employer.id);
+  res.json(recentJobs.slice(0, 5));
+}));
 
-employersRouter.get('/fulfilled-jobs', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const fulfilledJobs = await storage.getFulfilledJobsByEmployer(employer.id);
-    res.json(fulfilledJobs);
-  } catch (error) {
-    console.error('Fulfilled jobs fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch fulfilled jobs' });
+employersRouter.get('/fulfilled-jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const fulfilledJobs = await storage.getFulfilledJobsByEmployer(employer.id);
+  res.json(fulfilledJobs);
+}));
 
 // Job post creation via employers
-employersRouter.post('/jobs', authenticateUser, async (req: Request, res: Response) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({
-        error: 'Unauthorized',
-        message: 'Only verified employers can create job posts',
-      });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || employer.profileStatus !== 'verified') {
-      return res.status(403).json({
-        error: 'Unauthorized',
-        message: 'Your employer profile must be verified to create job posts',
-      });
-    }
-    const jobData = { ...req.body, employerId: employer.id, status: 'active', createdAt: new Date(), updatedAt: new Date() };
-    const jobPost = await storage.createJobPost(jobData);
-    res.status(201).json({ success: true, data: jobPost });
-  } catch (error: any) {
-    console.error('Job creation error:', error);
-    if (error.name === 'ZodError') {
-      return res.status(400).json({ success: false, error: 'Validation Error', message: 'Invalid data provided', details: error.errors });
-    }
-    res.status(500).json({ success: false, error: 'Internal Server Error', message: 'Failed to create job post' });
+employersRouter.post('/jobs', authenticateUser, asyncHandler(async (req: Request, res: Response) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({
+      error: 'Unauthorized',
+      message: 'Only verified employers can create job posts',
+    });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || employer.profileStatus !== 'verified') {
+    return res.status(403).json({
+      error: 'Unauthorized',
+      message: 'Your employer profile must be verified to create job posts',
+    });
+  }
+  const jobData = { ...req.body, employerId: employer.id, status: 'active', createdAt: new Date(), updatedAt: new Date() };
+  const jobPost = await storage.createJobPost(jobData);
+  res.status(201).json({ success: true, data: jobPost });
+}));
 
-employersRouter.get('/profile', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    res.json(employer);
-  } catch (error) {
-    console.error('Profile fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch profile' });
+employersRouter.get('/profile', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  res.json(employer);
+}));
 
-employersRouter.patch('/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employerId = parseInt(req.params.id);
-    const employer = await storage.getEmployer(employerId);
-    if (!employer || employer.userId !== user.id) {
-      return res.status(404).json({ message: 'Employer not found or access denied' });
-    }
-    const updatedEmployer = await storage.updateEmployer(employerId, req.body);
-    res.json(updatedEmployer);
-  } catch (error) {
-    console.error('Profile update error:', error);
-    res.status(400).json({ message: 'Failed to update profile' });
+employersRouter.patch('/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employerId = parseInt(req.params.id);
+  const employer = await storage.getEmployer(employerId);
+  if (!employer || employer.userId !== user.id) {
+    return res.status(404).json({ message: 'Employer not found or access denied' });
+  }
+  const updatedEmployer = await storage.updateEmployer(employerId, req.body);
+  res.json(updatedEmployer);
+}));
 
 // Generic job-post endpoint
-employersRouter.post('/job-posts', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    const jobData: InsertJobPost = insertJobPostSchema.parse({ ...req.body, employerId: employer.id });
-    const jobPost = await storage.createJobPost(jobData);
-    res.json(jobPost);
-  } catch (error) {
-    console.error('Job post creation error:', error);
-    res.status(400).json({ message: 'Failed to create job post' });
+employersRouter.post('/job-posts', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  const jobData: InsertJobPost = insertJobPostSchema.parse({ ...req.body, employerId: employer.id });
+  const jobPost = await storage.createJobPost(jobData);
+  res.json(jobPost);
+}));

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import { candidatesRouter } from './candidates';
 import { employersRouter } from './employers';
 import { jobsRouter } from './jobs';
 import { adminRouter } from './admin';
+import { errorHandler } from '../middleware/errorHandler';
 
 export async function registerRoutes(app: Express): Promise<Server> {
   app.use(express.json());
@@ -20,10 +21,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use('/api/jobs', jobsRouter);
   app.use('/api/admin', adminRouter);
 
-  app.use((err: any, _req: any, res: any, _next: any) => {
-    console.error(err.stack);
-    res.status(500).json({ error: 'Internal Server Error' });
-  });
+  app.use(errorHandler);
 
   const httpServer = createServer(app);
   return httpServer;

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -2,192 +2,155 @@ import { Router } from 'express';
 import { storage } from '../storage';
 import { insertJobPostSchema, type InsertJobPost } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
+import { asyncHandler } from '../middleware/asyncHandler';
 
 export const jobsRouter = Router();
 
-jobsRouter.patch('/:id/fulfill', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job || job.employerId !== employer.id) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    const fulfilledJob = await storage.markJobAsFulfilled(jobId);
-    res.json(fulfilledJob);
-  } catch (error) {
-    console.error('Job fulfillment error:', error);
-    res.status(500).json({ message: 'Failed to mark job as fulfilled' });
+jobsRouter.patch('/:id/fulfill', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job || job.employerId !== employer.id) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const fulfilledJob = await storage.markJobAsFulfilled(jobId);
+  res.json(fulfilledJob);
+}));
 
-jobsRouter.patch('/:id/activate', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job || job.employerId !== employer.id) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    if (job.fulfilled) {
-      return res.status(400).json({ message: 'Cannot activate a fulfilled job' });
-    }
-    const activatedJob = await storage.activateJob(jobId);
-    res.json(activatedJob);
-  } catch (error) {
-    console.error('Job activation error:', error);
-    res.status(500).json({ message: 'Failed to activate job' });
+jobsRouter.patch('/:id/activate', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job || job.employerId !== employer.id) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.fulfilled) {
+    return res.status(400).json({ message: 'Cannot activate a fulfilled job' });
+  }
+  const activatedJob = await storage.activateJob(jobId);
+  res.json(activatedJob);
+}));
 
-jobsRouter.patch('/:id/deactivate', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer) {
-      return res.status(404).json({ message: 'Employer profile not found' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job || job.employerId !== employer.id) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    if (job.fulfilled) {
-      return res.status(400).json({ message: 'Cannot deactivate a fulfilled job' });
-    }
-    const deactivatedJob = await storage.deactivateJob(jobId);
-    res.json(deactivatedJob);
-  } catch (error) {
-    console.error('Job deactivation error:', error);
-    res.status(500).json({ message: 'Failed to deactivate job' });
+jobsRouter.patch('/:id/deactivate', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer) {
+    return res.status(404).json({ message: 'Employer profile not found' });
+  }
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job || job.employerId !== employer.id) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.fulfilled) {
+    return res.status(400).json({ message: 'Cannot deactivate a fulfilled job' });
+  }
+  const deactivatedJob = await storage.deactivateJob(jobId);
+  res.json(deactivatedJob);
+}));
 
-jobsRouter.get('/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || job.employerId !== employer.id) {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    res.json(job);
-  } catch (error) {
-    console.error('Job fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch job details' });
+jobsRouter.get('/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || job.employerId !== employer.id) {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  res.json(job);
+}));
 
-jobsRouter.get('/:id/applications', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || job.employerId !== employer.id) {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const applications = await storage.getApplicationsByJob(jobId);
-    res.json(applications);
-  } catch (error) {
-    console.error('Applications fetch error:', error);
-    res.status(500).json({ message: 'Failed to fetch applications' });
+jobsRouter.get('/:id/applications', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || job.employerId !== employer.id) {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const applications = await storage.getApplicationsByJob(jobId);
+  res.json(applications);
+}));
 
-jobsRouter.put('/:id', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    if (job.fulfilled) {
-      return res.status(403).json({ message: 'Cannot edit fulfilled jobs' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || job.employerId !== employer.id) {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    if (employer.profileStatus !== 'verified') {
-      return res.status(403).json({ message: 'Employer not verified' });
-    }
-    const updateData = insertJobPostSchema.partial().parse(req.body) as Partial<InsertJobPost>;
-    const updatedJob = await storage.updateJobPost(jobId, updateData);
-    res.json(updatedJob);
-  } catch (error: any) {
-    console.error('Job update error:', error);
-    if (error.name === 'ZodError') {
-      return res.status(400).json({ message: 'Invalid data provided', details: error.errors });
-    }
-    res.status(500).json({ message: 'Failed to update job' });
+jobsRouter.put('/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.fulfilled) {
+    return res.status(403).json({ message: 'Cannot edit fulfilled jobs' });
+  }
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || job.employerId !== employer.id) {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  if (employer.profileStatus !== 'verified') {
+    return res.status(403).json({ message: 'Employer not verified' });
+  }
+  const updateData = insertJobPostSchema.partial().parse(req.body) as Partial<InsertJobPost>;
+  const updatedJob = await storage.updateJobPost(jobId, updateData);
+  res.json(updatedJob);
+}));
 
-jobsRouter.post('/:id/clone', authenticateUser, async (req: any, res) => {
-  try {
-    const user = await storage.getUserByFirebaseUid(req.user.uid);
-    if (!user || user.role !== 'employer') {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobId = parseInt(req.params.id);
-    const job = await storage.getJobPost(jobId);
-    if (!job) {
-      return res.status(404).json({ message: 'Job not found' });
-    }
-    const employer = await storage.getEmployerByUserId(user.id);
-    if (!employer || job.employerId !== employer.id) {
-      return res.status(403).json({ message: 'Access denied' });
-    }
-    const jobCode = `JOB-${Date.now()}-${Math.random().toString(36).substr(2, 4).toUpperCase()}`;
-    const cloneData = { ...job, title: `Copy of ${job.title}`, employerId: employer.id, jobCode, isActive: false };
-    const clonedJob = await storage.createJobPost(cloneData);
-    res.json(clonedJob);
-  } catch (error) {
-    console.error('Job clone error:', error);
-    res.status(500).json({ message: 'Failed to clone job' });
+jobsRouter.post('/:id/clone', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'employer') {
+    return res.status(403).json({ message: 'Access denied' });
   }
-});
+  const jobId = parseInt(req.params.id);
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const employer = await storage.getEmployerByUserId(user.id);
+  if (!employer || job.employerId !== employer.id) {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const jobCode = `JOB-${Date.now()}-${Math.random().toString(36).substr(2, 4).toUpperCase()}`;
+  const cloneData = { ...job, title: `Copy of ${job.title}`, employerId: employer.id, jobCode, isActive: false };
+  const clonedJob = await storage.createJobPost(cloneData);
+  res.json(clonedJob);
+}));


### PR DESCRIPTION
## Summary
- add asyncHandler middleware and use it across route files
- consolidate error handling through global errorHandler

## Testing
- `npm run check` *(fails: missing modules and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b7de110832ab7e61ca0f0ac5dd3