### PR TITLE
Remove ts-nocheck from client components

### DIFF
--- a/client/src/components/candidate/CandidateProfileEdit.tsx
+++ b/client/src/components/candidate/CandidateProfileEdit.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";

--- a/client/src/components/candidate/InterviewCoach.tsx
+++ b/client/src/components/candidate/InterviewCoach.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";

--- a/client/src/components/employer/EmployerDashboard.tsx
+++ b/client/src/components/employer/EmployerDashboard.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React, { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from "react";
 import { useParams, useLocation } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/client/src/components/employer/EmployerJobs.tsx
+++ b/client/src/components/employer/EmployerJobs.tsx
@@ -1,5 +1,3 @@
-// @ts-nocheck
-
 import React, { useState, useEffect, useDeferredValue } from "react";
 import { useDebounce } from "@/hooks/useDebounce";
 

--- a/client/src/components/employer/JobDetails.tsx
+++ b/client/src/components/employer/JobDetails.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from "react";
 import { useParams, Link } from "wouter";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";

--- a/client/src/hooks/useFileUpload.ts
+++ b/client/src/hooks/useFileUpload.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { useState } from "react";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { storage } from "@/lib/firebase";

--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";


### PR DESCRIPTION
## Summary
- re-enable TypeScript checking for several client files by removing `@ts-nocheck`

## Testing
- `npm run check` *(fails: Property 'pageSize' does not exist on type 'SearchParams', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f05c9c4832aa85240b119bd4878