### PR TITLE
Fix duplicate error handler

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,9 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes/index";
 import { setupVite, serveStatic, log } from "./vite";
+import { errorHandler } from "./middleware/errorHandler";
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -58,13 +59,7 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(errorHandler);
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -20,11 +20,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use('/api/jobs', jobsRouter);
   app.use('/api/admin', adminRouter);
 
-  app.use((err: any, _req: any, res: any, _next: any) => {
-    console.error(err.stack);
-    res.status(500).json({ error: 'Internal Server Error' });
-  });
-
   const httpServer = createServer(app);
   return httpServer;
 }


### PR DESCRIPTION
## Summary
- remove extra error handler middleware
- import and use common `errorHandler` once

## Testing
- `npm run check` *(fails: cannot find various names during type checking)*

------
https://chatgpt.com/codex/tasks/task_e_684c7141f44c832a803caaf0f0f1b207