### PR TITLE
Fix admin search router

### DIFF
--- a/server/routes/admin/search.ts
+++ b/server/routes/admin/search.ts
@@ -1,4 +1,5 @@
 import { eq, ilike, and, desc, asc, or } from "drizzle-orm";
+import { Router } from 'express';
 import { db } from "../../db";
 import { 
   candidates, 
@@ -303,3 +304,7 @@ function parseExperience(exp: string): number {
   if (exp === '10+ years') return 10;
   return 0;
 }
+
+export const adminSearchRouter = Router();
+
+adminSearchRouter.get('/', ...searchHandler);

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,6 +6,7 @@ import { candidatesRouter } from './candidates';
 import { employersRouter } from './employers';
 import { jobsRouter } from './jobs';
 import { adminRouter } from './admin';
+import { adminSearchRouter } from './admin/search';
 
 export async function registerRoutes(app: Express): Promise<Server> {
   app.use(express.json());
@@ -18,6 +19,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use('/api/candidates', candidatesRouter);
   app.use('/api/employers', employersRouter);
   app.use('/api/jobs', jobsRouter);
+  app.use('/api/admin/search', adminSearchRouter);
   app.use('/api/admin', adminRouter);
 
   app.use((err: any, _req: any, res: any, _next: any) => {


### PR DESCRIPTION
## Summary
- add `adminSearchRouter` router export
- mount `adminSearchRouter` at `/api/admin/search`

## Testing
- `npm run check` *(fails: Cannot find module '../db/schema', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684c70f6fb80832a919ce0d507ef4f81