### PR TITLE
Simplify verified role middleware

### DIFF
--- a/server/middleware/verifiedRole.ts
+++ b/server/middleware/verifiedRole.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from 'express';
+import { authenticateUser } from './authenticate';
+import { requireRole, ensureProfileVerified } from './authorization';
+
+export function requireVerifiedRole(role: 'candidate' | 'employer'): RequestHandler[] {
+  return [authenticateUser, requireRole(role), ensureProfileVerified(role)];
+}

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -1,16 +1,15 @@
 import { Router } from 'express';
 import { storage } from '../storage';
 import { insertCandidateSchema, type InsertCandidate } from '@shared/schema';
+import { requireVerifiedRole } from '../middleware/verifiedRole';
 import { authenticateUser } from '../middleware/authenticate';
-import { requireRole, ensureProfileVerified } from '../middleware/authorization';
+import { requireRole } from '../middleware/authorization';
 
 export const candidatesRouter = Router();
 
 candidatesRouter.get(
   '/profile',
-  authenticateUser,
-  requireRole('candidate'),
-  ensureProfileVerified('candidate'),
+  ...requireVerifiedRole('candidate'),
   async (req: any, res) => {
     try {
       const candidate = req.candidate;
@@ -64,9 +63,7 @@ candidatesRouter.post(
 
 candidatesRouter.get(
   '/stats',
-  authenticateUser,
-  requireRole('candidate'),
-  ensureProfileVerified('candidate'),
+  ...requireVerifiedRole('candidate'),
   async (req: any, res) => {
     try {
       const candidate = req.candidate;
@@ -81,9 +78,7 @@ candidatesRouter.get(
 
 candidatesRouter.get(
   '/recommended-jobs',
-  authenticateUser,
-  requireRole('candidate'),
-  ensureProfileVerified('candidate'),
+  ...requireVerifiedRole('candidate'),
   async (req: any, res) => {
     try {
       const candidate = req.candidate;
@@ -98,9 +93,7 @@ candidatesRouter.get(
 
 candidatesRouter.get(
   '/applications',
-  authenticateUser,
-  requireRole('candidate'),
-  ensureProfileVerified('candidate'),
+  ...requireVerifiedRole('candidate'),
   async (req: any, res) => {
     try {
       const candidate = req.candidate;

--- a/server/routes/employers.ts
+++ b/server/routes/employers.ts
@@ -2,7 +2,8 @@ import { Router, Request, Response } from 'express';
 import { storage } from '../storage';
 import { insertEmployerSchema, insertJobPostSchema, type InsertEmployer, type InsertJobPost } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
-import { requireRole, ensureProfileVerified } from '../middleware/authorization';
+import { requireRole } from '../middleware/authorization';
+import { requireVerifiedRole } from '../middleware/verifiedRole';
 
 export const employersRouter = Router();
 
@@ -35,9 +36,7 @@ employersRouter.post(
 
 employersRouter.get(
   '/stats',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -52,9 +51,7 @@ employersRouter.get(
 
 employersRouter.get(
   '/jobs',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -69,9 +66,7 @@ employersRouter.get(
 
 employersRouter.get(
   '/recent-jobs',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -86,9 +81,7 @@ employersRouter.get(
 
 employersRouter.get(
   '/fulfilled-jobs',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -104,9 +97,7 @@ employersRouter.get(
 // Job post creation via employers
 employersRouter.post(
   '/jobs',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: Request, res: Response) => {
     try {
       const employer = req.employer;

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -2,15 +2,14 @@ import { Router } from 'express';
 import { storage } from '../storage';
 import { insertJobPostSchema, type InsertJobPost } from '@shared/schema';
 import { authenticateUser } from '../middleware/authenticate';
-import { requireRole, ensureProfileVerified } from '../middleware/authorization';
+import { requireRole } from '../middleware/authorization';
+import { requireVerifiedRole } from '../middleware/verifiedRole';
 
 export const jobsRouter = Router();
 
 jobsRouter.patch(
   '/:id/fulfill',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -30,9 +29,7 @@ jobsRouter.patch(
 
 jobsRouter.patch(
   '/:id/activate',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -55,9 +52,7 @@ jobsRouter.patch(
 
 jobsRouter.patch(
   '/:id/deactivate',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -80,9 +75,7 @@ jobsRouter.patch(
 
 jobsRouter.get(
   '/:id',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -101,9 +94,7 @@ jobsRouter.get(
 
 jobsRouter.get(
   '/:id/applications',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -123,9 +114,7 @@ jobsRouter.get(
 
 jobsRouter.put(
   '/:id',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;
@@ -155,9 +144,7 @@ jobsRouter.put(
 
 jobsRouter.post(
   '/:id/clone',
-  authenticateUser,
-  requireRole('employer'),
-  ensureProfileVerified('employer'),
+  ...requireVerifiedRole('employer'),
   async (req: any, res) => {
     try {
       const employer = req.employer;


### PR DESCRIPTION
## Summary
- add `requireVerifiedRole` middleware to combine role checks
- use new middleware in candidate, employer and job routes

## Testing
- `npm install`
- `npm run check` *(fails: cannot find some type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684c7100b448832a8d81e956c71c68e3