### PR TITLE
Fix missing imports in server routes

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -7,6 +7,9 @@ import { z } from 'zod';
 import { AdminRepository } from '../repositories';
 import { calculateMatchScore } from '../utils/matchingEngine';
 import { exportToExcel, exportToPDF } from '../utils/exportUtils';
+import { storage } from '../storage';
+import { insertShortlistSchema } from '@shared/zod';
+import { verifyFirebaseToken } from '../utils/firebase-admin';
 
 // Validation schemas
 const searchQuerySchema = z.object({

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -7,6 +7,7 @@ import { requireRole } from '../middleware/authorization';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validateBody } from '../middleware/validation';
 import { CandidateRepository } from '../repositories';
+import { storage } from '../storage';
 
 export const candidatesRouter = Router();
 

--- a/server/routes/employers.ts
+++ b/server/routes/employers.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express';
-import { insertEmployerSchema } from '@shared/zod';
-import type { InsertEmployer } from '@shared/types';
+import { insertEmployerSchema, insertJobPostSchema } from '@shared/zod';
+import type { InsertEmployer, InsertJobPost } from '@shared/types';
 import { authenticateUser } from '../middleware/authenticate';
 import { requireRole } from '../middleware/authorization';
 import { requireVerifiedRole } from '../middleware/verifiedRole';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validateBody } from '../middleware/validation';
 import { EmployerRepository, JobPostRepository } from '../repositories';
+import { storage } from '../storage';
 
 export const employersRouter = Router();
 

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -7,6 +7,7 @@ import { requireVerifiedRole } from '../middleware/verifiedRole';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validateBody } from '../middleware/validation';
 import { JobPostRepository } from '../repositories';
+import { storage } from '../storage';
 
 export const jobsRouter = Router();
 


### PR DESCRIPTION
## Summary
- add missing storage and firebase imports
- add job post and shortlist schema imports

## Testing
- `npm run check` *(fails: cannot find type definitions and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684eeb2f3048832aa8e77a8cf5153232