### PR TITLE
Centralize dropdown option arrays

### DIFF
--- a/client/src/components/admin/AdminSearchPanel.tsx
+++ b/client/src/components/admin/AdminSearchPanel.tsx
@@ -11,6 +11,15 @@ import { apiRequest } from "@/lib/queryClient";
 import { debugLog } from "@/lib/logger";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useLocation } from "wouter";
+import {
+  qualifications,
+  experienceLevels,
+  profileStatus,
+  industries,
+  businessSizes,
+  jobCategories,
+  jobStatus,
+} from "@shared/constants";
 
 interface SearchFilters {
   qualification?: string;
@@ -141,54 +150,54 @@ export const AdminSearchPanel: React.FC = () => {
   // Filter definitions per type with predefined options
   const filterOptions = {
     candidate: [
-      { 
+      {
         key: "qualification",
         label: "Qualification",
-        options: ["Bachelor's", "Master's", "PhD", "High School", "Other"]
+        options: qualifications,
       },
-      { 
+      {
         key: "experience",
         label: "Experience Level",
-        options: ["0-2 years", "3-5 years", "5-10 years", "10+ years"]
+        options: ["0-2 years", "3-5 years", "5-10 years", "10+ years"],
       },
-      { 
+      {
         key: "status",
         label: "Verification Status",
-        options: ["verified", "pending", "rejected"]
+        options: profileStatus,
       },
     ],
     employer: [
-      { 
+      {
         key: "industry",
         label: "Industry",
-        options: ["Technology", "Healthcare", "Finance", "Education", "Manufacturing", "Other"]
+        options: industries,
       },
-      { 
+      {
         key: "size",
         label: "Business Size",
-        options: ["1-10", "11-50", "51-200", "201-1000", "1000+"]
+        options: businessSizes,
       },
-      { 
+      {
         key: "status",
         label: "Verification Status",
-        options: ["verified", "pending", "rejected"]
+        options: profileStatus,
       },
     ],
     job: [
-      { 
+      {
         key: "category",
         label: "Category",
-        options: ["Engineering", "Design", "Marketing", "Sales", "Management", "Other"]
+        options: jobCategories,
       },
-      { 
+      {
         key: "experience",
         label: "Experience Required",
-        options: ["Entry Level", "Mid Level", "Senior", "Lead", "Executive"]
+        options: experienceLevels,
       },
-      { 
+      {
         key: "status",
         label: "Status",
-        options: ["active", "inactive", "flagged"]
+        options: jobStatus,
       },
     ],
   };

--- a/client/src/components/candidate/CandidateProfileEdit.tsx
+++ b/client/src/components/candidate/CandidateProfileEdit.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { useFileUpload } from "@/hooks/useFileUpload";
+import { genders, maritalStatuses } from "@shared/constants";
 
 interface CandidateData {
   id: number;
@@ -263,10 +264,9 @@ export const CandidateProfileEdit: React.FC = () => {
                         <SelectValue placeholder="Select gender" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="male">Male</SelectItem>
-                        <SelectItem value="female">Female</SelectItem>
-                        <SelectItem value="other">Other</SelectItem>
-                        <SelectItem value="prefer-not-to-say">Prefer not to say</SelectItem>
+                        {genders.map((g) => (
+                          <SelectItem key={g} value={g}>{g.charAt(0).toUpperCase() + g.slice(1)}</SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </div>
@@ -277,10 +277,9 @@ export const CandidateProfileEdit: React.FC = () => {
                         <SelectValue placeholder="Select marital status" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="single">Single</SelectItem>
-                        <SelectItem value="married">Married</SelectItem>
-                        <SelectItem value="divorced">Divorced</SelectItem>
-                        <SelectItem value="widowed">Widowed</SelectItem>
+                        {maritalStatuses.map((m) => (
+                          <SelectItem key={m} value={m}>{m.charAt(0).toUpperCase() + m.slice(1)}</SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </div>

--- a/client/src/components/candidate/CandidateRegistration.tsx
+++ b/client/src/components/candidate/CandidateRegistration.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useFileUpload } from "@/hooks/useFileUpload";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { genders, maritalStatuses, allowedFileTypes } from "@shared/constants";
 
 interface CandidateFormData {
   dateOfBirth: string;
@@ -95,8 +96,7 @@ export const CandidateRegistration: React.FC = () => {
 
   const handleFileUpload = async (file: File, documentType: string) => {
     // Validate file type
-    const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'application/pdf'];
-    if (!allowedTypes.includes(file.type)) {
+    if (!allowedFileTypes.includes(file.type)) {
       toast({
         title: "Invalid File Type",
         description: "Please upload only PDF or image files (JPG, PNG)",
@@ -217,9 +217,9 @@ export const CandidateRegistration: React.FC = () => {
                     <SelectValue placeholder="Select Gender" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="male">Male</SelectItem>
-                    <SelectItem value="female">Female</SelectItem>
-                    <SelectItem value="other">Other</SelectItem>
+                    {genders.map((g) => (
+                      <SelectItem key={g} value={g}>{g.charAt(0).toUpperCase() + g.slice(1)}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -230,10 +230,9 @@ export const CandidateRegistration: React.FC = () => {
                     <SelectValue placeholder="Select Status" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="single">Single</SelectItem>
-                    <SelectItem value="married">Married</SelectItem>
-                    <SelectItem value="divorced">Divorced</SelectItem>
-                    <SelectItem value="widowed">Widowed</SelectItem>
+                    {maritalStatuses.map((m) => (
+                      <SelectItem key={m} value={m}>{m.charAt(0).toUpperCase() + m.slice(1)}</SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/client/src/components/candidate/InterviewCoach.tsx
+++ b/client/src/components/candidate/InterviewCoach.tsx
@@ -8,6 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
+import { interviewLevels } from "@shared/constants";
 import { 
   BrainCircuit, 
   MessageSquare, 
@@ -242,10 +243,9 @@ export const InterviewCoach: React.FC = () => {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="beginner">Beginner (Entry Level)</SelectItem>
-                  <SelectItem value="intermediate">Intermediate (2-5 years)</SelectItem>
-                  <SelectItem value="advanced">Advanced (5+ years)</SelectItem>
-                  <SelectItem value="senior">Senior (Leadership roles)</SelectItem>
+                  {interviewLevels.map((lvl) => (
+                    <SelectItem key={lvl} value={lvl}>{lvl}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/client/src/components/employer/EmployerJobCreate.tsx
+++ b/client/src/components/employer/EmployerJobCreate.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/hooks/use-toast";
+import { qualifications, experienceLevels } from "@shared/constants";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiRequest } from "@/lib/queryClient";
 import { ArrowLeft, Briefcase, Plus, Minus } from "lucide-react";
@@ -289,12 +290,9 @@ export const EmployerJobCreate: React.FC = () => {
                   <SelectValue placeholder="Select minimum qualification" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="High School">High School</SelectItem>
-                  <SelectItem value="Associate Degree">Associate Degree</SelectItem>
-                  <SelectItem value="Bachelor's Degree">Bachelor's Degree</SelectItem>
-                  <SelectItem value="Master's Degree">Master's Degree</SelectItem>
-                  <SelectItem value="PhD">PhD</SelectItem>
-                  <SelectItem value="Professional Certification">Professional Certification</SelectItem>
+                  {qualifications.map((q) => (
+                    <SelectItem key={q} value={q}>{q}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               {errors.minQualification && (
@@ -312,12 +310,9 @@ export const EmployerJobCreate: React.FC = () => {
                   <SelectValue placeholder="Select experience level" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Entry Level (0-1 years)">Entry Level (0-1 years)</SelectItem>
-                  <SelectItem value="Junior (1-3 years)">Junior (1-3 years)</SelectItem>
-                  <SelectItem value="Mid-Level (3-5 years)">Mid-Level (3-5 years)</SelectItem>
-                  <SelectItem value="Senior (5-8 years)">Senior (5-8 years)</SelectItem>
-                  <SelectItem value="Lead (8+ years)">Lead (8+ years)</SelectItem>
-                  <SelectItem value="Executive (10+ years)">Executive (10+ years)</SelectItem>
+                  {experienceLevels.map((lvl) => (
+                    <SelectItem key={lvl} value={lvl}>{lvl}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               {errors.experienceRequired && (

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -18,6 +18,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertJobPostSchema } from "@shared/zod";
 import { apiRequest } from "@/lib/queryClient";
+import { qualifications, experienceLevels } from "@shared/constants";
 import { debugLog } from "@/lib/logger";
 import { useToast } from "@/hooks/use-toast";
 import { z } from "zod";
@@ -253,12 +254,9 @@ export const EmployerJobEdit: React.FC = () => {
                   <SelectValue placeholder="Select minimum qualification" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="High School">High School</SelectItem>
-                  <SelectItem value="Associate Degree">Associate Degree</SelectItem>
-                  <SelectItem value="Bachelor's Degree">Bachelor's Degree</SelectItem>
-                  <SelectItem value="Master's Degree">Master's Degree</SelectItem>
-                  <SelectItem value="PhD">PhD</SelectItem>
-                  <SelectItem value="Professional Certification">Professional Certification</SelectItem>
+                  {qualifications.map((q) => (
+                    <SelectItem key={q} value={q}>{q}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               {form.formState.errors.minQualification && (
@@ -278,12 +276,9 @@ export const EmployerJobEdit: React.FC = () => {
                   <SelectValue placeholder="Select experience level" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Entry Level (0-1 years)">Entry Level (0-1 years)</SelectItem>
-                  <SelectItem value="Junior (1-3 years)">Junior (1-3 years)</SelectItem>
-                  <SelectItem value="Mid-Level (3-5 years)">Mid-Level (3-5 years)</SelectItem>
-                  <SelectItem value="Senior (5-8 years)">Senior (5-8 years)</SelectItem>
-                  <SelectItem value="Lead (8+ years)">Lead (8+ years)</SelectItem>
-                  <SelectItem value="Executive (10+ years)">Executive (10+ years)</SelectItem>
+                  {experienceLevels.map((lvl) => (
+                    <SelectItem key={lvl} value={lvl}>{lvl}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/client/src/components/employer/EmployerProfile.tsx
+++ b/client/src/components/employer/EmployerProfile.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
+import { businessTypes } from "@shared/constants";
 import { 
   Building, 
   Edit, 
@@ -123,18 +124,7 @@ export const EmployerProfile: React.FC = () => {
     });
   };
 
-  const businessTypes = [
-    "Technology",
-    "Healthcare",
-    "Finance",
-    "Education",
-    "Manufacturing",
-    "Retail",
-    "Consulting",
-    "Government",
-    "Non-profit",
-    "Other"
-  ];
+
 
   if (isLoading) {
     return (

--- a/client/src/components/employer/EmployerRegistration.tsx
+++ b/client/src/components/employer/EmployerRegistration.tsx
@@ -11,6 +11,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { debugLog } from "@/lib/logger";
 import { useLocation } from "wouter";
+import { businessTypes } from "@shared/constants";
 
 interface EmployerFormData {
   organizationName: string;
@@ -193,18 +194,7 @@ export const EmployerRegistration: React.FC = () => {
     createEmployerMutation.mutate(formData);
   };
 
-  const businessTypes = [
-    "Technology",
-    "Healthcare",
-    "Finance",
-    "Education",
-    "Manufacturing",
-    "Retail",
-    "Consulting",
-    "Government",
-    "Non-profit",
-    "Other"
-  ];
+
 
   // Show loading while checking for existing profile
   if (checkingProfile) {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,109 @@
+export const businessTypes = [
+  "Technology",
+  "Healthcare",
+  "Finance",
+  "Education",
+  "Manufacturing",
+  "Retail",
+  "Consulting",
+  "Government",
+  "Non-profit",
+  "Other"
+];
+
+export const qualifications = [
+  "High School",
+  "Associate Degree",
+  "Bachelor's Degree",
+  "Master's Degree",
+  "PhD",
+  "Professional Certification"
+];
+
+export const experienceLevels = [
+  "Entry Level (0-1 years)",
+  "Junior (1-3 years)",
+  "Mid-Level (3-5 years)",
+  "Senior (5-8 years)",
+  "Lead (8+ years)",
+  "Executive (10+ years)"
+];
+
+export const genders = [
+  "male",
+  "female",
+  "other",
+  "prefer-not-to-say"
+];
+
+export const maritalStatuses = [
+  "single",
+  "married",
+  "divorced",
+  "widowed"
+];
+
+export const profileStatus = [
+  "verified",
+  "pending",
+  "rejected"
+];
+
+export const jobStatus = [
+  "active",
+  "inactive",
+  "flagged"
+];
+
+export const applicationStatus = [
+  "pending",
+  "reviewed",
+  "shortlisted",
+  "interviewed",
+  "hired",
+  "rejected"
+];
+
+export const businessSizes = [
+  "1-10",
+  "11-50",
+  "51-200",
+  "201-1000",
+  "1000+"
+];
+
+export const industries = [
+  "Technology",
+  "Healthcare",
+  "Finance",
+  "Education",
+  "Manufacturing",
+  "Retail",
+  "Consulting",
+  "Government",
+  "Non-profit",
+  "Other"
+];
+
+export const jobCategories = [
+  "Engineering",
+  "Design",
+  "Marketing",
+  "Sales",
+  "Management",
+  "Other"
+];
+
+export const allowedFileTypes = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "application/pdf"
+];
+
+export const interviewLevels = [
+  "beginner",
+  "intermediate",
+  "advanced",
+  "senior"
+];


### PR DESCRIPTION
## Summary
- add shared constants for dropdown options
- reuse shared lists in employer, candidate and admin components
- update interview coach to use the shared levels list

## Testing
- `npm run check` *(fails: TS errors in server routes)*

------
https://chatgpt.com/codex/tasks/task_e_684eff878a30832aae11cd522f08220a