### PR TITLE
Fix gender options for candidate forms

### DIFF
--- a/client/src/components/candidate/CandidateProfileEdit.tsx
+++ b/client/src/components/candidate/CandidateProfileEdit.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { useFileUpload } from "@/hooks/useFileUpload";
+import { genders } from "@shared/constants";
 
 interface CandidateData {
   id: number;
@@ -263,10 +264,11 @@ export const CandidateProfileEdit: React.FC = () => {
                         <SelectValue placeholder="Select gender" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="male">Male</SelectItem>
-                        <SelectItem value="female">Female</SelectItem>
-                        <SelectItem value="other">Other</SelectItem>
-                        <SelectItem value="prefer-not-to-say">Prefer not to say</SelectItem>
+                        {genders.map((g) => (
+                          <SelectItem key={g} value={g}>
+                            {g.charAt(0).toUpperCase() + g.slice(1)}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </div>

--- a/client/src/components/candidate/CandidateRegistration.tsx
+++ b/client/src/components/candidate/CandidateRegistration.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useFileUpload } from "@/hooks/useFileUpload";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/components/auth/AuthProvider";
+import { genders } from "@shared/constants";
 
 interface CandidateFormData {
   dateOfBirth: string;
@@ -217,9 +218,11 @@ export const CandidateRegistration: React.FC = () => {
                     <SelectValue placeholder="Select Gender" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="male">Male</SelectItem>
-                    <SelectItem value="female">Female</SelectItem>
-                    <SelectItem value="other">Other</SelectItem>
+                    {genders.map((g) => (
+                      <SelectItem key={g} value={g}>
+                        {g.charAt(0).toUpperCase() + g.slice(1)}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,2 @@
+export const genders = ["male", "female", "other"] as const;
+export type Gender = typeof genders[number];


### PR DESCRIPTION
## Summary
- centralize gender options in a new shared constant
- use genders constant in candidate profile editor
- use genders constant in candidate registration

## Testing
- `npm run check` *(fails: error TS2345, TS2339, TS2349, TS2551, TS2353)*

------
https://chatgpt.com/codex/tasks/task_e_684effadd87c832ab67d8ecc0238b28d