### PR TITLE
Unify experience level labels

### DIFF
--- a/client/src/components/admin/AdminSearchPanel.tsx
+++ b/client/src/components/admin/AdminSearchPanel.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Filter, Search, SortAsc, MoreVertical, Eye, Edit, Trash2, CheckCircle, User, Building2, FileText, FlaskConical, Users, Briefcase, MapPin, Calendar } from "lucide-react";
+import { experienceLevels } from "@shared/constants";
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { debugLog } from "@/lib/logger";
@@ -180,10 +181,10 @@ export const AdminSearchPanel: React.FC = () => {
         label: "Category",
         options: ["Engineering", "Design", "Marketing", "Sales", "Management", "Other"]
       },
-      { 
+      {
         key: "experience",
         label: "Experience Required",
-        options: ["Entry Level", "Mid Level", "Senior", "Lead", "Executive"]
+        options: experienceLevels
       },
       { 
         key: "status",

--- a/client/src/components/employer/EmployerJobCreate.tsx
+++ b/client/src/components/employer/EmployerJobCreate.tsx
@@ -22,6 +22,7 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { apiRequest } from "@/lib/queryClient";
 import { ArrowLeft, Briefcase, Plus, Minus } from "lucide-react";
 import { jobPostValidationSchema } from "@shared/zod";
+import { experienceLevels } from "@shared/constants";
 
 type JobPostFormData = z.infer<typeof jobPostValidationSchema>;
 
@@ -312,12 +313,9 @@ export const EmployerJobCreate: React.FC = () => {
                   <SelectValue placeholder="Select experience level" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Entry Level (0-1 years)">Entry Level (0-1 years)</SelectItem>
-                  <SelectItem value="Junior (1-3 years)">Junior (1-3 years)</SelectItem>
-                  <SelectItem value="Mid-Level (3-5 years)">Mid-Level (3-5 years)</SelectItem>
-                  <SelectItem value="Senior (5-8 years)">Senior (5-8 years)</SelectItem>
-                  <SelectItem value="Lead (8+ years)">Lead (8+ years)</SelectItem>
-                  <SelectItem value="Executive (10+ years)">Executive (10+ years)</SelectItem>
+                  {experienceLevels.map(level => (
+                    <SelectItem key={level} value={level}>{level}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               {errors.experienceRequired && (

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -18,6 +18,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertJobPostSchema } from "@shared/zod";
 import { apiRequest } from "@/lib/queryClient";
+import { experienceLevels } from "@shared/constants";
 import { debugLog } from "@/lib/logger";
 import { useToast } from "@/hooks/use-toast";
 import { z } from "zod";
@@ -278,12 +279,9 @@ export const EmployerJobEdit: React.FC = () => {
                   <SelectValue placeholder="Select experience level" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Entry Level (0-1 years)">Entry Level (0-1 years)</SelectItem>
-                  <SelectItem value="Junior (1-3 years)">Junior (1-3 years)</SelectItem>
-                  <SelectItem value="Mid-Level (3-5 years)">Mid-Level (3-5 years)</SelectItem>
-                  <SelectItem value="Senior (5-8 years)">Senior (5-8 years)</SelectItem>
-                  <SelectItem value="Lead (8+ years)">Lead (8+ years)</SelectItem>
-                  <SelectItem value="Executive (10+ years)">Executive (10+ years)</SelectItem>
+                  {experienceLevels.map(level => (
+                    <SelectItem key={level} value={level}>{level}</SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,3 +1,4 @@
+// Consistent labels used across admin filters and employer forms
 export const experienceLevels = [
   "Entry Level (0-1 years)",
   "Junior (1-3 years)",

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,10 @@
+export const experienceLevels = [
+  "Entry Level (0-1 years)",
+  "Junior (1-3 years)",
+  "Mid-Level (3-5 years)",
+  "Senior (5-8 years)",
+  "Lead (8+ years)",
+  "Executive (10+ years)"
+] as const;
+
+export type ExperienceLevel = typeof experienceLevels[number];


### PR DESCRIPTION
## Summary
- centralize experience level options in a shared constant
- use the constant in the admin search filter dropdown
- use the constant in employer job create/edit forms
- remove stray AdminSearchPanel artifact

## Testing
- `npm install`
- `npm run check` *(fails: Property errors in server routes)*

------
https://chatgpt.com/codex/tasks/task_e_684f01508944832a8fedb7949f575e5a