### PR TITLE
Fix admin portal features

### DIFF
--- a/client/src/components/admin/AdminDashboard.tsx
+++ b/client/src/components/admin/AdminDashboard.tsx
@@ -2,10 +2,8 @@ import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Users, Briefcase, TrendingUp, Download, Bot } from "lucide-react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { MatchingEngine } from "./MatchingEngine";
-import { apiRequest, throwIfResNotOk } from "@/lib/queryClient";
-import { useToast } from "@/hooks/use-toast";
 import { debugLog } from "@/lib/logger";
 
 export const AdminDashboard: React.FC = () => {
@@ -13,42 +11,7 @@ export const AdminDashboard: React.FC = () => {
     queryKey: ["/api/admin/stats"],
   });
 
-  const { data: unverifiedEmployers } = useQuery({
-    queryKey: ["/api/admin/unverified-employers"],
-  });
 
-  const { data: unverifiedCandidates } = useQuery({
-    queryKey: ["/api/admin/unverified-candidates"],
-  });
-
-  const queryClient = useQueryClient();
-  const { toast } = useToast();
-
-  const verifyEmployerMutation = useMutation({
-    mutationFn: async (id: number) => {
-      const res = await apiRequest(`/api/admin/employers/${id}/verify`, "PATCH");
-      await throwIfResNotOk(res);
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/admin/unverified-employers"] });
-      toast({ title: "Employer verified" });
-    },
-    onError: () => toast({ title: "Failed", variant: "destructive" }),
-  });
-
-  const verifyCandidateMutation = useMutation({
-    mutationFn: async (id: number) => {
-      const res = await apiRequest(`/api/admin/candidates/${id}/verify`, "PATCH");
-      await throwIfResNotOk(res);
-      return res.json();
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["/api/admin/unverified-candidates"] });
-      toast({ title: "Candidate verified" });
-    },
-    onError: () => toast({ title: "Failed", variant: "destructive" }),
-  });
 
   const handleExportData = () => {
     // Implement export functionality
@@ -65,52 +28,18 @@ export const AdminDashboard: React.FC = () => {
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
         <div className="flex space-x-4">
-          <Button onClick={handleExportData} variant="outline">
+          <Button onClick={handleExportData} variant="outline" disabled>
             <Download className="h-4 w-4 mr-2" />
             Export Data
           </Button>
-          <Button onClick={handleRunMatching} className="bg-green-600 hover:bg-green-700">
+          <Button onClick={handleRunMatching} variant="outline" disabled>
             <Bot className="h-4 w-4 mr-2" />
             Run Matching
           </Button>
         </div>
       </div>
 
-      {/* Verification queues */}
-      <div className="grid md:grid-cols-2 gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Unverified Employers</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {(unverifiedEmployers || []).map((emp: any) => (
-              <div key={emp.id} className="flex justify-between items-center py-2 border-b last:border-b-0">
-                <span>{emp.organizationName}</span>
-                <Button size="sm" onClick={() => verifyEmployerMutation.mutate(emp.id)} disabled={verifyEmployerMutation.isPending}>
-                  Verify
-                </Button>
-              </div>
-            ))}
-            {(unverifiedEmployers || []).length === 0 && <p className="text-sm text-muted-foreground">None</p>}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Unverified Candidates</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {(unverifiedCandidates || []).map((cand: any) => (
-              <div key={cand.id} className="flex justify-between items-center py-2 border-b last:border-b-0">
-                <span>{cand.userId}</span>
-                <Button size="sm" onClick={() => verifyCandidateMutation.mutate(cand.id)} disabled={verifyCandidateMutation.isPending}>
-                  Verify
-                </Button>
-              </div>
-            ))}
-            {(unverifiedCandidates || []).length === 0 && <p className="text-sm text-muted-foreground">None</p>}
-          </CardContent>
-        </Card>
-      </div>
+
 
       {/* Statistics Cards */}
       <div className="grid lg:grid-cols-4 md:grid-cols-2 gap-6">

--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -23,7 +23,7 @@ export const MatchingEngine: React.FC = () => {
   });
 
   const { data: candidates } = useQuery({
-    queryKey: ["/api/admin/candidates"],
+    queryKey: ["/api/admin/active-candidates"],
   });
 
   const shortlistMutation = useMutation({
@@ -121,7 +121,7 @@ export const MatchingEngine: React.FC = () => {
       {/* Candidates with Job Matches */}
       <Card>
         <CardHeader>
-          <CardTitle>Top Candidates</CardTitle>
+          <CardTitle>Most Active Candidates</CardTitle>
           <p className="text-sm text-gray-600">
             Click on a candidate to find matching jobs
           </p>

--- a/client/src/components/auth/LoginModal.tsx
+++ b/client/src/components/auth/LoginModal.tsx
@@ -17,9 +17,16 @@ import { ConfirmationResult } from "firebase/auth";
 interface LoginModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onLoginSuccess?: () => void;
+  roleHint?: string;
 }
 
-export const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
+export const LoginModal: React.FC<LoginModalProps> = ({
+  isOpen,
+  onClose,
+  onLoginSuccess,
+  roleHint,
+}) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [phone, setPhone] = useState("");
@@ -39,6 +46,12 @@ export const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
         description: "Logged in successfully!",
       });
       onClose();
+      if (onLoginSuccess) {
+        onLoginSuccess();
+      }
+      if (onLoginSuccess) {
+        onLoginSuccess();
+      }
     } catch (error: any) {
       console.error("Login error:", error);
       

--- a/client/src/components/common/Navbar.tsx
+++ b/client/src/components/common/Navbar.tsx
@@ -110,13 +110,15 @@ export const Navbar: React.FC = () => {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-56 bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700">
-                <Link href={userProfile?.role === "employer" ? "/employer/profile" : "/profile"}>
-                  <DropdownMenuItem>
-                    <User className="mr-2 h-4 w-4" />
-                    <span>Profile</span>
-                  </DropdownMenuItem>
-                </Link>
-                <DropdownMenuSeparator />
+                {userProfile?.role !== "admin" && (
+                  <Link href={userProfile?.role === "employer" ? "/employer/profile" : "/profile"}>
+                    <DropdownMenuItem>
+                      <User className="mr-2 h-4 w-4" />
+                      <span>Profile</span>
+                    </DropdownMenuItem>
+                  </Link>
+                )}
+                {userProfile?.role !== "admin" && <DropdownMenuSeparator />}
                 <DropdownMenuItem onClick={signOut}>
                   <LogOut className="mr-2 h-4 w-4" />
                   <span>Sign Out</span>

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -14,7 +14,7 @@ export const Admin: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [, setLocation] = useLocation();
   const { toast } = useToast();
-  const { user, userProfile, loading: authLoading } = useAuth();
+  const { user, userProfile, loading: authLoading, refreshProfile } = useAuth();
 
   // Early redirect for admin users
   useEffect(() => {
@@ -54,6 +54,7 @@ export const Admin: React.FC = () => {
       if (!response.ok) throw new Error("Not an admin or invalid credentials");
       const data = await response.json();
       toast({ title: "Welcome, Admin!", description: data.user.name || data.user.email });
+      refreshProfile();
       setShowLoginModal(false);
       setLocation("/admin/dashboard");
     } catch (error: any) {

--- a/server/repositories/CandidateRepository.ts
+++ b/server/repositories/CandidateRepository.ts
@@ -211,6 +211,28 @@ export class CandidateRepository {
   }
 
   /**
+   * Retrieve the most active candidates based on application count
+   */
+  static async getMostActiveCandidates(limit = 10) {
+    return db
+      .select({
+        candidate: candidates,
+        user: {
+          name: users.name,
+          email: users.email,
+        },
+        applications: sql<number>`count(${applications.id})`.as('applications'),
+      })
+      .from(candidates)
+      .innerJoin(users, eq(users.id, candidates.userId))
+      .leftJoin(applications, eq(applications.candidateId, candidates.id))
+      .where(and(eq(candidates.deleted, false), eq(candidates.profileStatus, 'verified')))
+      .groupBy(candidates.id, users.id)
+      .orderBy(desc(sql`count(${applications.id})`))
+      .limit(limit);
+  }
+
+  /**
    * Placeholder for recommended jobs
    */
   static async getRecommendedJobs(_candidateId: number) {

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -263,6 +263,15 @@ adminRouter.get('/candidates', authenticateUser, asyncHandler(async (req: any, r
   res.json(candidates);
 }));
 
+adminRouter.get('/active-candidates', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const candidates = await storage.getMostActiveCandidates(10);
+  res.json(candidates);
+}));
+
 adminRouter.get('/jobs/:jobId/matches', authenticateUser, asyncHandler(async (req: any, res) => {
   const user = await storage.getUserByFirebaseUid(req.user.uid);
   if (!user || user.role !== 'admin') {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -95,6 +95,7 @@ export interface IStorage {
   // Admin operations
   getAdminStats(): Promise<any>;
   getExportData(): Promise<any>;
+  getMostActiveCandidates(limit?: number): Promise<any[]>;
 }
 
 export class DatabaseStorage implements IStorage {
@@ -405,6 +406,10 @@ export class DatabaseStorage implements IStorage {
       applications: allApplications,
       shortlists: allShortlists,
     };
+  }
+
+  async getMostActiveCandidates(limit = 10): Promise<any[]> {
+    return CandidateRepository.getMostActiveCandidates(limit);
   }
 }
 


### PR DESCRIPTION
## Summary
- update login modal to emit success callback
- show sign out only for admin in Navbar
- refresh profile after admin login
- remove verification lists from admin dashboard
- disable pending features buttons
- fetch most active candidates for matching engine
- provide API route and repository method for active candidates

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684fb43bfed0832ab0bebd0965060caf