### PR TITLE
Fix AdminDashboard active jobs count

### DIFF
--- a/client/src/components/admin/AdminDashboard.tsx
+++ b/client/src/components/admin/AdminDashboard.tsx
@@ -69,7 +69,7 @@ export const AdminDashboard: React.FC = () => {
               <div>
                 <p className="text-sm text-gray-600">Active Jobs</p>
                 <p className="text-2xl font-bold text-gray-900">
-                  {stats?.jobs || 0}
+                  {stats?.jobs?.activeJobs || 0}
                 </p>
               </div>
               <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">


### PR DESCRIPTION
## Summary
- show the active jobs count in AdminDashboard

## Testing
- `npm run check` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684fbbc0b584832a82ac3afee16c98a7