### PR TITLE
Fix candidate list key handling

### DIFF
--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -128,9 +128,9 @@ export const MatchingEngine: React.FC = () => {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {candidates?.map((candidate: any) => (
+            {candidates?.map((candidate: any, index: number) => (
               <div
-                key={candidate.id}
+                key={candidate.id ?? candidate.candidate?.id ?? index}
                 className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
                 onClick={() => handleCandidateClick(candidate)}
               >


### PR DESCRIPTION
## Summary
- fix keys for candidate list items in MatchingEngine

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_684fc0eab884832a8eef5fc895bfd579