### PR TITLE
Enable navigation to job details from matching engine

### DIFF
--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -8,6 +8,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { MatchingModal } from "./MatchingModal";
+import { Link } from "wouter";
 
 export const MatchingEngine: React.FC = () => {
   const [selectedJob, setSelectedJob] = useState<any>(null);
@@ -45,11 +46,6 @@ export const MatchingEngine: React.FC = () => {
     },
   });
 
-  const handleJobClick = (job: any) => {
-    setSelectedJob(job);
-    setMatchingType("job-candidates");
-    setShowMatchingModal(true);
-  };
 
   const handleCandidateClick = (candidate: any) => {
     setSelectedCandidate(candidate);
@@ -78,12 +74,11 @@ export const MatchingEngine: React.FC = () => {
         <CardContent>
           <div className="space-y-4">
             {jobs?.map((job: any) => (
-              <div
-                key={job.id}
-                className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
-                onClick={() => handleJobClick(job)}
-              >
-                <div className="flex justify-between items-start">
+              <Link key={job.id} href={`/jobs/${job.id}`}>
+                <div
+                  className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
+                >
+                  <div className="flex justify-between items-start">
                   <div className="flex-1">
                     <h3 className="font-semibold text-gray-900">{job.title}</h3>
                     <p className="text-sm text-gray-600">{job.company?.name || 'Company Name'}</p>
@@ -105,7 +100,8 @@ export const MatchingEngine: React.FC = () => {
                     <div className="text-xs text-gray-500">matches</div>
                   </div>
                 </div>
-              </div>
+                </div>
+              </Link>
             ))}
 
             {(!jobs || jobs.length === 0) && (


### PR DESCRIPTION
## Summary
- update `MatchingEngine` to link job cards to job details
- import `Link` from `wouter`
- remove unused job click handler

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684fc0b26368832a88dfc6ca4894fafc