### PR TITLE
Add candidate details admin route and page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import { EmployerJobCreate } from "./components/employer/EmployerJobCreate";
 import { EmployerJobEdit } from "./components/employer/EmployerJobEdit";
 import { JobDetails } from "./components/employer/JobDetails";
 import { EmployerProfile } from "./components/employer/EmployerProfile";
+import { CandidateDetails } from "./components/admin/CandidateDetails";
 import { AdminDashboard } from "./components/admin/AdminDashboard";
 import { AdminSearchPanel } from "./components/admin/AdminSearchPanel";
 import { AdminVerifications } from "./components/admin/AdminVerifications";
@@ -230,6 +231,15 @@ function Router() {
             <div className="min-h-screen bg-background">
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 <JobDetails />
+              </div>
+            </div>
+          </ProtectedRoute>
+        </Route>
+        <Route path="/candidates/:id">
+          <ProtectedRoute>
+            <div className="min-h-screen bg-background">
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <CandidateDetails />
               </div>
             </div>
           </ProtectedRoute>

--- a/client/src/components/admin/CandidateDetails.tsx
+++ b/client/src/components/admin/CandidateDetails.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { useParams, Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, User, Briefcase } from "lucide-react";
+
+export const CandidateDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+
+  const { data: candidate, isLoading } = useQuery({
+    queryKey: [`/api/admin/candidates/${id}`],
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <Card className="animate-pulse bg-card border-border">
+          <CardContent className="p-6 space-y-4">
+            <div className="h-6 bg-muted rounded w-1/3"></div>
+            <div className="h-4 bg-muted rounded w-1/2"></div>
+            <div className="h-4 bg-muted rounded w-1/4"></div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!candidate) {
+    return (
+      <div className="max-w-3xl mx-auto">
+        <Card>
+          <CardContent className="p-12 text-center">
+            <h3 className="text-lg font-medium text-foreground mb-2">
+              Candidate not found
+            </h3>
+            <Link href="/admin/tools">
+              <Button>
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-6">
+      <div className="flex items-center gap-2">
+        <Link href="/admin/tools">
+          <Button variant="outline" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+        </Link>
+        <h1 className="text-3xl font-bold text-foreground">Candidate Details</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <User className="h-5 w-5" />
+            Personal Information
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <span className="text-muted-foreground">Date of Birth:</span>{" "}
+              <span className="font-medium">{candidate.dateOfBirth || "-"}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Gender:</span>{" "}
+              <span className="font-medium capitalize">
+                {candidate.gender || "-"}
+              </span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Marital Status:</span>{" "}
+              <span className="font-medium capitalize">
+                {candidate.maritalStatus || "-"}
+              </span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Dependents:</span>{" "}
+              <span className="font-medium">{candidate.dependents ?? "-"}</span>
+            </div>
+            <div className="md:col-span-2">
+              <span className="text-muted-foreground">Address:</span>{" "}
+              <span className="font-medium">{candidate.address || "-"}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Briefcase className="h-5 w-5" />
+            Professional Details
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <span className="text-muted-foreground">Expected Salary:</span>{" "}
+              <span className="font-medium">
+                {candidate.expectedSalary ? `$${candidate.expectedSalary}` : "-"}
+              </span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">Languages:</span>{" "}
+              <span className="font-medium">
+                {Array.isArray(candidate.languages)
+                  ? candidate.languages.join(", ")
+                  : "-"}
+              </span>
+            </div>
+            <div className="md:col-span-2">
+              <span className="text-muted-foreground">Skills:</span>{" "}
+              <span className="font-medium">
+                {Array.isArray(candidate.skills)
+                  ? candidate.skills.join(", ")
+                  : "-"}
+              </span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -8,6 +8,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { MatchingModal } from "./MatchingModal";
+import { Link } from "wouter";
 
 export const MatchingEngine: React.FC = () => {
   const [selectedJob, setSelectedJob] = useState<any>(null);
@@ -129,18 +130,22 @@ export const MatchingEngine: React.FC = () => {
         <CardContent>
           <div className="space-y-4">
             {candidates?.map((candidate: any) => (
-              <div
+              <Link
                 key={candidate.id}
-                className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
-                onClick={() => handleCandidateClick(candidate)}
+                href={`/candidates/${candidate.id}`}
+                className="block"
               >
-                <div className="flex items-center space-x-4">
-                  <Avatar className="h-12 w-12">
-                    <AvatarImage src={candidate.avatar} alt={
-                      typeof candidate.name === 'object'
-                        ? `${candidate.name.first || ''} ${candidate.name.last || ''}`
-                        : candidate.name || 'Candidate'
-                    } />
+                <div
+                  className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
+                  onClick={() => handleCandidateClick(candidate)}
+                >
+                  <div className="flex items-center space-x-4">
+                    <Avatar className="h-12 w-12">
+                      <AvatarImage src={candidate.avatar} alt={
+                        typeof candidate.name === 'object'
+                          ? `${candidate.name.first || ''} ${candidate.name.last || ''}`
+                          : candidate.name || 'Candidate'
+                      } />
                     <AvatarFallback>
                       {typeof candidate.name === 'object'
                         ? `${(candidate.name.first?.[0] || '')}${(candidate.name.last?.[0] || '')}`
@@ -179,8 +184,9 @@ export const MatchingEngine: React.FC = () => {
                     </div>
                     <div className="text-xs text-gray-500">job matches</div>
                   </div>
+                  </div>
                 </div>
-              </div>
+              </Link>
             ))}
 
             {(!candidates || candidates.length === 0) && (

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -272,6 +272,19 @@ adminRouter.get('/active-candidates', authenticateUser, asyncHandler(async (req:
   res.json(candidates);
 }));
 
+adminRouter.get('/candidates/:id', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const id = parseInt(req.params.id);
+  const candidate = await storage.getCandidate(id);
+  if (!candidate) {
+    return res.status(404).json({ message: 'Candidate not found' });
+  }
+  res.json(candidate);
+}));
+
 adminRouter.get('/jobs/:jobId/matches', authenticateUser, asyncHandler(async (req: any, res) => {
   const user = await storage.getUserByFirebaseUid(req.user.uid);
   if (!user || user.role !== 'admin') {


### PR DESCRIPTION
## Summary
- add admin route to fetch candidate by id
- show candidate information in new `CandidateDetails` component
- wire candidate details route in client router
- link candidate cards in matching engine to new page

## Testing
- `npm run check` *(fails: server routes have type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684fc0d5a798832a817ec09a76409290