### PR TITLE
Allow admins to manage job posts

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,8 @@ import { EmployerJobEdit } from "./components/employer/EmployerJobEdit";
 import { JobDetails } from "./components/employer/JobDetails";
 import { EmployerProfile } from "./components/employer/EmployerProfile";
 import { CandidateDetails } from "./components/admin/CandidateDetails";
+import { AdminJobDetails } from "./components/admin/AdminJobDetails";
+import { AdminJobEdit } from "./components/admin/AdminJobEdit";
 import { AdminDashboard } from "./components/admin/AdminDashboard";
 import { AdminSearchPanel } from "./components/admin/AdminSearchPanel";
 import { AdminVerifications } from "./components/admin/AdminVerifications";
@@ -127,6 +129,24 @@ function Router() {
             <div className="min-h-screen bg-background">
               <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
                 <AdminTools />
+              </div>
+            </div>
+          </ProtectedRoute>
+        </Route>
+        <Route path="/admin/jobs/:id/edit">
+          <ProtectedRoute>
+            <div className="min-h-screen bg-background">
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <AdminJobEdit />
+              </div>
+            </div>
+          </ProtectedRoute>
+        </Route>
+        <Route path="/admin/jobs/:id">
+          <ProtectedRoute>
+            <div className="min-h-screen bg-background">
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <AdminJobDetails />
               </div>
             </div>
           </ProtectedRoute>

--- a/client/src/components/admin/AdminJobDetails.tsx
+++ b/client/src/components/admin/AdminJobDetails.tsx
@@ -1,0 +1,370 @@
+import React from "react";
+import { useParams, Link } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useLocation } from "wouter";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ArrowLeft,
+  MapPin,
+  Calendar,
+  Users,
+  Briefcase,
+  DollarSign,
+  Building,
+  MoreVertical,
+  Edit,
+  Trash,
+  CheckCircle,
+  FileText,
+  Clock,
+  Mail,
+  Phone,
+} from "lucide-react";
+import type { JobPost, Application, Employer } from "@shared/types";
+import { formatDistanceToNow } from "date-fns";
+
+export const AdminJobDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [, setLocation] = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data: job, isLoading } = useQuery<JobPost>({
+    queryKey: [`/api/admin/jobs/${id}`],
+    enabled: !!id,
+  });
+
+  const { data: employer } = useQuery<Employer>({
+    queryKey: job ? [`/api/admin/employers/${job.employerId}`] : [],
+    enabled: !!job?.employerId,
+  });
+
+  const { data: applications = [], isLoading: appsLoading } = useQuery<Application[]>({
+    queryKey: [`/api/admin/jobs/${id}/applications`],
+    enabled: !!id,
+  });
+
+  const fulfillMutation = useMutation({
+    mutationFn: () => apiRequest(`/api/admin/jobs/${id}/fulfill`, "PATCH"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/admin/jobs/${id}`] });
+      toast({ title: "Success", description: "Job marked as fulfilled" });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => apiRequest(`/api/admin/jobs/${id}`, "DELETE"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/jobs"] });
+      setLocation("/admin/dashboard");
+      toast({ title: "Deleted", description: "Job deleted" });
+    },
+  });
+
+  if (isLoading || appsLoading) {
+    return (
+      <div className="max-w-6xl mx-auto space-y-6">
+        <Card className="animate-pulse bg-card border-border">
+          <CardContent className="p-6 space-y-4">
+            <div className="h-6 bg-muted rounded w-1/3"></div>
+            <div className="h-4 bg-muted rounded w-1/2"></div>
+            <div className="h-4 bg-muted rounded w-1/4"></div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="max-w-6xl mx-auto">
+        <Card>
+          <CardContent className="p-12 text-center">
+            <h3 className="text-lg font-medium text-foreground mb-2">Job not found</h3>
+            <Link href="/admin/dashboard">
+              <Button>
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "fulfilled":
+        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400";
+      case "active":
+        return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400";
+      case "dormant":
+        return "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400";
+      case "inactive":
+        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400";
+      default:
+        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400";
+    }
+  };
+
+  const getApplicationStatusColor = (status: string) => {
+    switch (status?.toLowerCase()) {
+      case "applied":
+        return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400";
+      case "reviewed":
+        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400";
+      case "shortlisted":
+        return "bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-400";
+      case "interviewed":
+        return "bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-400";
+      case "hired":
+        return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400";
+      case "rejected":
+        return "bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-400";
+      default:
+        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400";
+    }
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto space-y-6">
+      <div className="flex items-center gap-2">
+        <Link href="/admin/dashboard">
+          <Button variant="outline" size="sm">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back
+          </Button>
+        </Link>
+        <h1 className="text-3xl font-bold text-foreground">{job.title}</h1>
+        <Badge className={getStatusColor(job.fulfilled ? 'fulfilled' : (job.isActive ? 'active' : 'inactive'))}>
+          {job.fulfilled ? 'Fulfilled' : (job.isActive ? 'Active' : 'Inactive')}
+        </Badge>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm">
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <Link href={`/admin/jobs/${job.id}/edit`}>
+                <Edit className="h-4 w-4 mr-2" />
+                Edit Job
+              </Link>
+            </DropdownMenuItem>
+            {!job.fulfilled && (
+              <DropdownMenuItem onClick={() => fulfillMutation.mutate()} disabled={fulfillMutation.isPending}>
+                <CheckCircle className="h-4 w-4 mr-2" />
+                {fulfillMutation.isPending ? 'Marking...' : 'Mark as Fulfilled'}
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onClick={() => deleteMutation.mutate()} disabled={deleteMutation.isPending}>
+              <Trash className="h-4 w-4 mr-2" />
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete Job'}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Briefcase className="h-5 w-5" />
+                Job Details
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="flex items-center gap-2 text-sm">
+                  <MapPin className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Location:</span>
+                  <span className="font-medium">{job.location}</span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <DollarSign className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Salary:</span>
+                  <span className="font-medium text-green-600">{job.salaryRange}</span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <Users className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Positions:</span>
+                  <span className="font-medium">{job.vacancy || 1}</span>
+                </div>
+                <div className="flex items-center gap-2 text-sm">
+                  <Calendar className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-muted-foreground">Posted:</span>
+                  <span className="font-medium">
+                    {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
+                  </span>
+                </div>
+              </div>
+
+              <Separator />
+
+              <div>
+                <h3 className="font-semibold mb-2">Job Description</h3>
+                <p className="text-muted-foreground leading-relaxed">
+                  {job.description || "No description provided."}
+                </p>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">Minimum Qualification</h3>
+                <p className="text-muted-foreground">{job.minQualification}</p>
+              </div>
+
+              <div>
+                <h3 className="font-semibold mb-2">Required Skills</h3>
+                <div className="flex flex-wrap gap-2">
+                  {job.skills?.split(',').map((skill: string, index: number) => (
+                    <Badge key={index} variant="secondary">
+                      {skill.trim()}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+
+              {job.responsibilities && (
+                <div>
+                  <h3 className="font-semibold mb-2">Responsibilities</h3>
+                  <div className="text-muted-foreground whitespace-pre-line">
+                    {job.responsibilities}
+                  </div>
+                </div>
+              )}
+
+              {job.experienceRequired && (
+                <div>
+                  <h3 className="font-semibold mb-2">Experience Required</h3>
+                  <p className="text-muted-foreground">{job.experienceRequired}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Building className="h-5 w-5" />
+                Employer Info
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <div className="font-semibold">{employer?.organizationName}</div>
+              <div className="text-sm text-muted-foreground">{employer?.contactEmail}</div>
+              <div className="text-sm text-muted-foreground">{employer?.contactPhone}</div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Job Statistics</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Total Applications</span>
+                <span className="font-bold text-2xl">{applications.length}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Views</span>
+                <span className="font-bold text-2xl">0</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Days Active</span>
+                <span className="font-bold text-2xl">
+                  {Math.floor((new Date().getTime() - new Date(job.createdAt).getTime()) / (1000 * 60 * 60 * 24))}
+                </span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <FileText className="h-5 w-5" />
+              Applications ({applications.length})
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {applications.length > 0 ? (
+            <div className="space-y-4">
+              {applications.map((application: any) => (
+                <div
+                  key={application.id}
+                  className="flex items-center justify-between p-4 border border-border rounded-lg hover:bg-accent/50 transition-colors"
+                >
+                  <div className="flex items-center gap-4">
+                    <Avatar>
+                      <AvatarFallback>
+                        {application.candidateName?.charAt(0) || 'A'}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <h3 className="font-semibold">{application.candidateName || 'Anonymous Candidate'}</h3>
+                      <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                        <div className="flex items-center gap-1">
+                          <Clock className="h-4 w-4" />
+                          Applied {formatDistanceToNow(new Date(application.appliedAt), { addSuffix: true })}
+                        </div>
+                        {application.candidateEmail && (
+                          <div className="flex items-center gap-1">
+                            <Mail className="h-4 w-4" />
+                            {application.candidateEmail}
+                          </div>
+                        )}
+                        {application.candidatePhone && (
+                          <div className="flex items-center gap-1">
+                            <Phone className="h-4 w-4" />
+                            {application.candidatePhone}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <Badge className={getApplicationStatusColor(application.status)}>
+                    {application.status || 'Applied'}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <FileText className="h-16 w-16 text-muted mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-foreground mb-2">No applications yet</h3>
+              <p className="text-muted-foreground">
+                Applications will appear here when candidates apply for this position.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/client/src/components/admin/AdminJobEdit.tsx
+++ b/client/src/components/admin/AdminJobEdit.tsx
@@ -1,0 +1,352 @@
+import React from "react";
+import { useParams, useLocation } from "wouter";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { 
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ArrowLeft, Save } from "lucide-react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { insertJobPostSchema } from "@shared/zod";
+import { apiRequest } from "@/lib/queryClient";
+
+import { qualifications, experienceLevels } from "@shared/constants";
+
+import { debugLog } from "@/lib/logger";
+import { useToast } from "@/hooks/use-toast";
+import { z } from "zod";
+
+const editJobSchema = insertJobPostSchema.extend({
+  title: z.string().min(1, "Job title is required"),
+  minQualification: z.string().min(1, "Minimum qualification is required"),
+  skills: z.string().min(1, "Skills are required"),
+  responsibilities: z.string().min(1, "Responsibilities are required"),
+  vacancy: z.coerce.number().min(1, "Number of positions must be at least 1"),
+  employerId: z.any().optional(),
+  jobCode: z.any().optional(),
+});
+
+type EditJobFormData = z.infer<typeof editJobSchema>;
+
+export const AdminJobEdit: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: job, isLoading } = useQuery({
+    queryKey: [`/api/admin/jobs/${id}`],
+    enabled: !!id,
+  });
+
+  const form = useForm<EditJobFormData>({
+    resolver: zodResolver(editJobSchema),
+    defaultValues: {
+      title: "",
+      description: "",
+      minQualification: "",
+      experienceRequired: "",
+      skills: "",
+      salaryRange: "",
+      location: "",
+      responsibilities: "",
+      vacancy: 1,
+    },
+  });
+
+  // Update form when job data loads
+  React.useEffect(() => {
+    if (job) {
+      form.reset({
+        title: job.title || "",
+        description: job.description || "",
+        minQualification: job.minQualification || "",
+        experienceRequired: job.experienceRequired || "",
+        skills: job.skills || "",
+        salaryRange: job.salaryRange || "",
+        location: job.location || "",
+        responsibilities: job.responsibilities || "",
+        vacancy: job.vacancy || 1,
+      });
+    }
+  }, [job, form]);
+
+  const updateJobMutation = useMutation({
+    mutationFn: (data: EditJobFormData) =>
+      apiRequest(`/api/admin/jobs/${id}`, "PUT", data),
+    onSuccess: () => {
+      toast({
+        title: "Success",
+        description: "Job updated successfully",
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/jobs"] });
+      queryClient.invalidateQueries({ queryKey: [`/api/admin/jobs/${id}`] });
+      setLocation(`/admin/jobs/${id}`);
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to update job",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: EditJobFormData) => {
+    debugLog("onSubmit called with data:", data);
+    updateJobMutation.mutate(data);
+  };
+
+  React.useEffect(() => {
+    if (form.formState.errors && Object.keys(form.formState.errors).length > 0) {
+      debugLog("Form validation errors:", form.formState.errors);
+    }
+  }, [form.formState.errors]);
+
+  React.useEffect(() => {
+    if (updateJobMutation.isError) {
+      debugLog("Mutation error:", updateJobMutation.error);
+    }
+    if (updateJobMutation.isSuccess) {
+      debugLog("Mutation success");
+    }
+    if (updateJobMutation.isPending) {
+      debugLog("Mutation pending...");
+    }
+  }, [updateJobMutation.isError, updateJobMutation.isSuccess, updateJobMutation.isPending, updateJobMutation.error]);
+
+  if (isLoading) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6">
+        <div className="animate-pulse">
+          <div className="h-8 bg-muted rounded w-1/3 mb-4"></div>
+          <div className="h-96 bg-muted rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <Card>
+          <CardContent className="p-12 text-center">
+            <h3 className="text-lg font-medium text-foreground mb-2">Job not found</h3>
+            <p className="text-muted-foreground mb-6">
+              The job you're trying to edit doesn't exist or has been removed.
+            </p>
+            <Button onClick={() => setLocation("/admin/dashboard")}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Jobs
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  // Check if job is fulfilled and prevent editing
+  if (job.fulfilled) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <Card>
+          <CardContent className="p-12 text-center">
+            <h3 className="text-lg font-medium text-foreground mb-2">Cannot Edit Fulfilled Job</h3>
+            <p className="text-muted-foreground mb-6">
+              This job has been marked as fulfilled and cannot be edited. You can clone this job to create a new posting.
+            </p>
+            <div className="flex gap-4 justify-center">
+              <Button onClick={() => setLocation("/admin/dashboard")}>
+                <ArrowLeft className="h-4 w-4 mr-2" />
+                Back to Jobs
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center gap-4">
+        <Button variant="outline" onClick={() => setLocation("/admin/dashboard")}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Jobs
+        </Button>
+        <div>
+          <h1 className="text-3xl font-bold text-foreground">Edit Job</h1>
+          <p className="text-muted-foreground">Update job details and requirements</p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Job Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <Label htmlFor="title">Job Title *</Label>
+                <Input
+                  id="title"
+                  {...form.register("title")}
+                  placeholder="e.g., Senior Software Engineer"
+                />
+                {form.formState.errors.title && (
+                  <p className="text-sm text-destructive">
+                    {form.formState.errors.title.message}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="vacancy">Number of Positions *</Label>
+                <Input
+                  id="vacancy"
+                  type="number"
+                  min="1"
+                  {...form.register("vacancy")}
+                  placeholder="1"
+                />
+                {form.formState.errors.vacancy && (
+                  <p className="text-sm text-destructive">
+                    {form.formState.errors.vacancy.message}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="description">Job Description</Label>
+              <Textarea
+                id="description"
+                {...form.register("description")}
+                placeholder="Describe the role, company culture, and what makes this opportunity unique..."
+                rows={4}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="minQualification">Minimum Qualification *</Label>
+              <Select
+                value={form.watch("minQualification")}
+                onValueChange={(value) => form.setValue("minQualification", value)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select minimum qualification" />
+                </SelectTrigger>
+                <SelectContent>
+                  {qualifications.map((q) => (
+                    <SelectItem key={q} value={q}>{q}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {form.formState.errors.minQualification && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.minQualification.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="experienceRequired">Experience Required</Label>
+              <Select
+                value={form.watch("experienceRequired")}
+                onValueChange={(value) => form.setValue("experienceRequired", value)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select experience level" />
+                </SelectTrigger>
+                <SelectContent>
+                  {experienceLevels.map(level => (
+                    <SelectItem key={level} value={level}>{level}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="skills">Required Skills *</Label>
+              <Textarea
+                id="skills"
+                {...form.register("skills")}
+                placeholder="e.g., JavaScript, React, Node.js, TypeScript (separate with commas)"
+                rows={3}
+              />
+              {form.formState.errors.skills && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.skills.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="responsibilities">Key Responsibilities *</Label>
+              <Textarea
+                id="responsibilities"
+                {...form.register("responsibilities")}
+                placeholder="List the main responsibilities and duties for this role..."
+                rows={4}
+              />
+              {form.formState.errors.responsibilities && (
+                <p className="text-sm text-destructive">
+                  {form.formState.errors.responsibilities.message}
+                </p>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <Label htmlFor="salaryRange">Salary Range</Label>
+                <Input
+                  id="salaryRange"
+                  {...form.register("salaryRange")}
+                  placeholder="e.g., ₹8,00,000 - ₹12,00,000"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="location">Location</Label>
+                <Input
+                  id="location"
+                  {...form.register("location")}
+                  placeholder="e.g., San Francisco, CA or Remote"
+                />
+              </div>
+            </div>
+
+            <div className="flex gap-4 pt-6">
+              <Button
+                type="submit"
+                disabled={updateJobMutation.isPending}
+                className="bg-primary hover:bg-primary/90"
+              >
+                <Save className="h-4 w-4 mr-2" />
+                {updateJobMutation.isPending ? "Updating..." : "Update Job"}
+              </Button>
+              
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setLocation("/admin/dashboard")}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -74,7 +74,7 @@ export const MatchingEngine: React.FC = () => {
         <CardContent>
           <div className="space-y-4">
             {jobs?.map((job: any) => (
-              <Link key={job.id} href={`/jobs/${job.id}`}>
+              <Link key={job.id} href={`/admin/jobs/${job.id}`}>
                 <div
                   className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
                 >


### PR DESCRIPTION
## Summary
- support admin edit and fulfill job routes
- show employer info on admin job details
- add admin job edit page and routing
- expose admin job update and fulfill API endpoints

## Testing
- `npm run check` *(fails: TypeScript errors in existing server files)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6bc1178832a97a937c73c94e46b