### PR TITLE
Fix admin search results display

### DIFF
--- a/server/repositories/AdminRepository.ts
+++ b/server/repositories/AdminRepository.ts
@@ -112,25 +112,31 @@ export class AdminRepository {
     // Implementation depends on your search requirements
     // This is a basic example
     if (type === 'candidate') {
-      return db
+      const results = await db
         .select()
         .from(candidates)
         .innerJoin(users, eq(users.id, candidates.userId))
         .where(sql`to_tsvector('english', ${users.name}) @@ plainto_tsquery('english', ${query})`);
+
+      return results.map((r) => ({ ...r, type: 'candidate' }));
     }
 
     if (type === 'employer') {
-      return db
+      const results = await db
         .select()
         .from(employers)
         .where(sql`to_tsvector('english', organization_name) @@ plainto_tsquery('english', ${query})`);
+
+      return results.map((r) => ({ ...r, type: 'employer' }));
     }
 
     if (type === 'job') {
-      return db
+      const results = await db
         .select()
         .from(jobPosts)
         .where(sql`to_tsvector('english', title || ' ' || description) @@ plainto_tsquery('english', ${query})`);
+
+      return results.map((r) => ({ ...r, type: 'job' }));
     }
 
     // Search all by default


### PR DESCRIPTION
## Summary
- ensure admin search results include `type` field

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684ff628f5c0832aab1725d94c91578e