### PR TITLE
Show toast on admin verification query failure

### DIFF
--- a/client/src/components/admin/AdminVerifications.tsx
+++ b/client/src/components/admin/AdminVerifications.tsx
@@ -33,7 +33,23 @@ export const AdminVerifications: React.FC = () => {
   // Fetch pending verifications based on type
   const { data: verifications = [], isLoading } = useQuery({
     queryKey: [`/api/admin/verifications/${type}`],
-    enabled: !!type
+    enabled: !!type,
+    onError: (error: any) => {
+      const message = error?.message || "Failed to fetch verifications";
+      if (typeof message === 'string' && message.toLowerCase().includes('unauthorized')) {
+        toast({
+          title: 'Unauthorized',
+          description: 'You are not authorized to view this content.',
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: 'Error',
+          description: message,
+          variant: 'destructive',
+        });
+      }
+    },
   });
 
   // Mutations for verification actions


### PR DESCRIPTION
## Summary
- surface fetch errors on the Admin Verifications page
- show an Unauthorized toast when a 401 occurs

## Testing
- `npm run check`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68500379efb8832a877f50617aa3703c