### PR TITLE
Refactor MatchingEngine to use reusable cards

### DIFF
--- a/client/src/components/admin/MatchingEngine.tsx
+++ b/client/src/components/admin/MatchingEngine.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
-import { Building, MapPin, DollarSign, Clock, User, Briefcase } from "lucide-react";
+import { User, Briefcase } from "lucide-react";
+import { JobCard, CandidateCard } from "@/components/common";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
@@ -75,32 +74,14 @@ export const MatchingEngine: React.FC = () => {
           <div className="space-y-4">
             {jobs?.map((job: any) => (
               <Link key={job.id} href={`/admin/jobs/${job.id}`}>
-                <div
-                  className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors"
-                >
-                  <div className="flex justify-between items-start">
-                  <div className="flex-1">
-                    <h3 className="font-semibold text-gray-900">{job.title}</h3>
-                    <p className="text-sm text-gray-600">{job.company?.name || 'Company Name'}</p>
-                    <div className="flex items-center space-x-4 mt-2">
-                      <Badge variant="outline" className="text-xs">
-                        <MapPin className="h-3 w-3 mr-1" />
-                        {job.location?.city || job.location || 'Location'}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs">
-                        <DollarSign className="h-3 w-3 mr-1" />
-                        {job.salaryRange || 'Salary range'}
-                      </Badge>
-                    </div>
-                  </div>
+                <JobCard job={job}>
                   <div className="text-right">
                     <div className="text-lg font-bold text-green-600">
                       {job.matchCount || 0}
                     </div>
                     <div className="text-xs text-gray-500">matches</div>
                   </div>
-                </div>
-                </div>
+                </JobCard>
               </Link>
             ))}
 
@@ -129,54 +110,14 @@ export const MatchingEngine: React.FC = () => {
                 key={candidate.id ?? candidate.candidate?.id ?? index}
                 href={`/candidates/${candidate.id ?? candidate.candidate?.id ?? ''}`}
               >
-                <div className="p-4 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors">
-                  <div className="flex items-center space-x-4">
-                    <Avatar className="h-12 w-12">
-                      <AvatarImage src={candidate.avatar} alt={
-                        typeof candidate.name === 'object'
-                          ? `${candidate.name.first || ''} ${candidate.name.last || ''}`
-                          : candidate.name || 'Candidate'
-                      } />
-                    <AvatarFallback>
-                      {typeof candidate.name === 'object'
-                        ? `${(candidate.name.first?.[0] || '')}${(candidate.name.last?.[0] || '')}`
-                        : (candidate.name?.split(" ").map((n: string) => n[0]).join("") || "?")}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="flex-1">
-                    <h3 className="font-semibold text-gray-900">
-                      {typeof candidate.name === 'object' 
-                        ? `${candidate.name.first || ''} ${candidate.name.last || ''}`
-                        : candidate.name || 'Candidate'}
-                    </h3>
-                    <p className="text-sm text-gray-600">
-                      {typeof candidate.role === 'object'
-                        ? candidate.role.title || "Professional"
-                        : candidate.role || "Professional"}
-                    </p>
-                    <div className="flex items-center space-x-2 mt-1">
-                      <Badge variant="outline" className="text-xs">
-                        <Clock className="h-3 w-3 mr-1" />
-                        {typeof candidate.experience === 'object'
-                          ? `${candidate.experience.years || 0} years`
-                          : `${candidate.experience || 0} years`}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs">
-                        <MapPin className="h-3 w-3 mr-1" />
-                        {typeof candidate.location === 'object'
-                          ? candidate.location.city || 'Location'
-                          : candidate.location || 'Location'}
-                      </Badge>
-                    </div>
-                  </div>
+                <CandidateCard candidate={candidate}>
                   <div className="text-right">
                     <div className="text-lg font-bold text-primary">
                       {candidate.jobMatches || 0}
                     </div>
                     <div className="text-xs text-gray-500">job matches</div>
                   </div>
-                  </div>
-                </div>
+                </CandidateCard>
               </Link>
             ))}
 

--- a/client/src/components/common/CandidateCard.tsx
+++ b/client/src/components/common/CandidateCard.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { Card } from "@/components/ui/card";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, Clock } from "lucide-react";
+
+interface CandidateCardProps {
+  candidate: any;
+  children?: React.ReactNode;
+}
+
+export const CandidateCard: React.FC<CandidateCardProps> = ({ candidate, children }) => (
+  <Card className="border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors">
+    <div className="p-4">
+      <div className="flex items-center space-x-4">
+        <Avatar className="h-12 w-12">
+          <AvatarImage
+            src={candidate.avatar}
+            alt={
+              typeof candidate.name === "object"
+                ? `${candidate.name.first || ""} ${candidate.name.last || ""}`
+                : candidate.name || "Candidate"
+            }
+          />
+          <AvatarFallback>
+            {typeof candidate.name === "object"
+              ? `${candidate.name.first?.[0] || ""}${candidate.name.last?.[0] || ""}`
+              : candidate.name?.split(" ").map((n: string) => n[0]).join("") || "?"}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex-1">
+          <h3 className="font-semibold text-gray-900">
+            {typeof candidate.name === "object"
+              ? `${candidate.name.first || ""} ${candidate.name.last || ""}`
+              : candidate.name || "Candidate"}
+          </h3>
+          <p className="text-sm text-gray-600">
+            {typeof candidate.role === "object" ? candidate.role.title || "Professional" : candidate.role || "Professional"}
+          </p>
+          <div className="flex items-center space-x-2 mt-1">
+            <Badge variant="outline" className="text-xs">
+              <Clock className="h-3 w-3 mr-1" />
+              {typeof candidate.experience === "object" ? `${candidate.experience.years || 0} years` : `${candidate.experience || 0} years`}
+            </Badge>
+            <Badge variant="outline" className="text-xs">
+              <MapPin className="h-3 w-3 mr-1" />
+              {typeof candidate.location === "object" ? candidate.location.city || "Location" : candidate.location || "Location"}
+            </Badge>
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+  </Card>
+);
+

--- a/client/src/components/common/JobCard.tsx
+++ b/client/src/components/common/JobCard.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, DollarSign } from "lucide-react";
+
+interface JobCardProps {
+  job: any;
+  children?: React.ReactNode;
+}
+
+export const JobCard: React.FC<JobCardProps> = ({ job, children }) => (
+  <Card className="border border-gray-200 hover:bg-gray-50 cursor-pointer transition-colors">
+    <div className="p-4">
+      <div className="flex justify-between items-start">
+        <div className="flex-1">
+          <h3 className="font-semibold text-gray-900">{job.title}</h3>
+          <p className="text-sm text-gray-600">{job.company?.name || "Company Name"}</p>
+          <div className="flex items-center space-x-4 mt-2">
+            <Badge variant="outline" className="text-xs">
+              <MapPin className="h-3 w-3 mr-1" />
+              {job.location?.city || job.location || "Location"}
+            </Badge>
+            <Badge variant="outline" className="text-xs">
+              <DollarSign className="h-3 w-3 mr-1" />
+              {job.salaryRange || "Salary range"}
+            </Badge>
+          </div>
+        </div>
+        {children}
+      </div>
+    </div>
+  </Card>
+);
+

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,0 +1,4 @@
+export { Chatbot } from "./Chatbot";
+export { Navbar } from "./Navbar";
+export { JobCard } from "./JobCard";
+export { CandidateCard } from "./CandidateCard";


### PR DESCRIPTION
## Summary
- add reusable `JobCard` and `CandidateCard`
- update `MatchingEngine` to use the new cards
- export cards from common components module
- run `npm run check`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6850119f7420832a843a45e26b0c14a0