### PR TITLE
Fix JSX closing tag error in CandidateJobs

### DIFF
--- a/client/src/components/candidate/CandidateJobs.tsx
+++ b/client/src/components/candidate/CandidateJobs.tsx
@@ -180,6 +180,8 @@ export const CandidateJobs: React.FC = () => {
                 </div>
               )}
 
+              </div>
+
               <div className="flex justify-between items-center">
                 <div className="flex items-center gap-1 text-green-600 dark:text-green-400">
                   <DollarSign className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- close missing `<div>` in `CandidateJobs` component

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_685013dde254832ab85ce356f6de3454