### PR TITLE
Fix CandidateJobs closing tag

### DIFF
--- a/client/src/components/candidate/CandidateJobs.tsx
+++ b/client/src/components/candidate/CandidateJobs.tsx
@@ -191,7 +191,6 @@ export const CandidateJobs: React.FC = () => {
                   Apply Now
                 </Button>
               </div>
-            </CardContent>
           </JobCard>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- remove unmatched `CardContent` closing tag from `CandidateJobs`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685016671e0c832a9493d50e7092d1b8