### PR TITLE
Remove obsolete job post status field

### DIFF
--- a/server/repositories/JobRepository.ts
+++ b/server/repositories/JobRepository.ts
@@ -19,7 +19,7 @@ export class JobRepository {
       .insert(jobPosts)
       .values({
         ...insertJobPost,
-        isActive: true,
+        isActive: false,
         applicationsCount: 0,
       })
       .returning();
@@ -37,24 +37,24 @@ export class JobRepository {
   }
 
   static async getJobPostsByEmployer(employerId: number): Promise<(JobPost & { status: string })[]> {
-    const jobs = await db
-      .select()
-      .from(jobPosts)
-      .where(eq(jobPosts.employerId, employerId));
-    return jobs.map((j) => ({ ...j, status: getJobStatus(j) }));
+      const jobs = await db
+        .select()
+        .from(jobPosts)
+        .where(eq(jobPosts.employerId, employerId));
+      return jobs.map((j: JobPost) => ({ ...j, status: getJobStatus(j) }));
   }
 
   static async getAllJobPosts(): Promise<(JobPost & { status: string })[]> {
-    const jobs = await db.select().from(jobPosts);
-    return jobs.map((j) => ({ ...j, status: getJobStatus(j) }));
+      const jobs = await db.select().from(jobPosts);
+      return jobs.map((j: JobPost) => ({ ...j, status: getJobStatus(j) }));
   }
 
   static async getInactiveJobs(): Promise<(JobPost & { status: string })[]> {
-    const jobs = await db
-      .select()
-      .from(jobPosts)
-      .where(eq(jobPosts.isActive, false));
-    return jobs.map((j) => ({ ...j, status: getJobStatus(j) }));
+      const jobs = await db
+        .select()
+        .from(jobPosts)
+        .where(eq(jobPosts.isActive, false));
+      return jobs.map((j: JobPost) => ({ ...j, status: getJobStatus(j) }));
   }
 
   static async markJobAsFulfilled(jobId: number): Promise<JobPost & { status: string }> {

--- a/server/routes/employers.ts
+++ b/server/routes/employers.ts
@@ -83,7 +83,7 @@ employersRouter.post(
   ...requireVerifiedRole('employer'),
   asyncHandler(async (req: any, res: any) => {
     const employer = req.employer;
-    const jobData = { ...req.body, employerId: employer.id, status: 'active', createdAt: new Date(), updatedAt: new Date() };
+    const jobData = { ...req.body, employerId: employer.id, createdAt: new Date(), updatedAt: new Date() };
     const jobPost = await storage.createJobPost(jobData);
     res.status(201).json({ success: true, data: jobPost });
   })

--- a/shared/types/jobPosts.ts
+++ b/shared/types/jobPosts.ts
@@ -4,7 +4,7 @@ import { jobPostValidationSchema, jobPostSearchSchema } from '../zod';
 export type JobPostValidation = z.infer<typeof jobPostValidationSchema>;
 export type CreateJobPostInput = Omit<
   JobPostValidation,
-  'id' | 'jobCode' | 'status' | 'createdAt' | 'updatedAt'
+  'id' | 'jobCode' | 'createdAt' | 'updatedAt'
 >;
 export type UpdateJobPostInput = Partial<CreateJobPostInput>;
 export type JobPostSearchParams = z.infer<typeof jobPostSearchSchema>;
@@ -19,7 +19,6 @@ export interface JobPostResponse {
   };
   title: string;
   location: string;
-  status: string;
   createdAt: Date;
 }
 

--- a/shared/zod/jobPosts.ts
+++ b/shared/zod/jobPosts.ts
@@ -35,8 +35,6 @@ export const jobPostValidationSchema = z.object({
   employerId: z.number()
     .int()
     .positive('Invalid employer ID'),
-  status: z.enum(['draft', 'active', 'inactive', 'fulfilled'])
-    .default('draft'),
   createdAt: z.date().optional(),
   updatedAt: z.date().optional()
 });
@@ -46,7 +44,6 @@ export const jobPostSearchSchema = z.object({
   location: z.string().optional(),
   experienceLevel: z.string().optional(),
   employerId: z.number().optional(),
-  status: z.enum(['draft', 'active', 'inactive', 'fulfilled']).optional(),
   sortBy: z.enum(['latest', 'salary', 'relevance']).optional(),
   page: z.number().int().positive().optional(),
   limit: z.number().int().positive().max(100).optional()


### PR DESCRIPTION
## Summary
- drop `status` from job post types and validation
- remove status handling in `JobPostRepository` and routes
- default new job posts to `isActive: false`
- annotate JobRepository map callbacks for tsc

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6851842cbb38832ab22200f37b221437