### PR TITLE
Implement cron job to deactivate stale posts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "lucide-react": "^0.453.0",
         "memorystore": "^1.6.7",
         "next-themes": "^0.4.6",
+        "node-cron": "^4.1.0",
         "openai": "^5.1.1",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
@@ -9128,6 +9129,15 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lucide-react": "^0.453.0",
     "memorystore": "^1.6.7",
     "next-themes": "^0.4.6",
+    "node-cron": "^4.1.0",
     "openai": "^5.1.1",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes/index";
 import { setupVite, serveStatic, log } from "./vite";
 import { errorHandler } from "./middleware/errorHandler";
+import { scheduleDeactivateOldPostsJob } from "./jobs/deactivateOldPosts";
 
 const app = express();
 app.use(express.json({ limit: '50mb' }));
@@ -58,6 +59,8 @@ app.use((req, res, next) => {
 
 (async () => {
   const server = await registerRoutes(app);
+
+  scheduleDeactivateOldPostsJob();
 
   app.use(errorHandler);
 

--- a/server/jobs/deactivateOldPosts.ts
+++ b/server/jobs/deactivateOldPosts.ts
@@ -1,0 +1,21 @@
+import cron from 'node-cron';
+import { db } from '../db';
+import { jobPosts } from '@shared/schema';
+import { and, eq, lt } from 'drizzle-orm';
+
+export function scheduleDeactivateOldPostsJob() {
+  cron.schedule('0 0 * * *', async () => {
+    const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    await db
+      .update(jobPosts)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(
+        and(
+          lt(jobPosts.createdAt, ninetyDaysAgo),
+          eq(jobPosts.fulfilled, false),
+          eq(jobPosts.isActive, true),
+          eq(jobPosts.deleted, false)
+        )
+      );
+  });
+}


### PR DESCRIPTION
## Summary
- add `node-cron` dependency
- schedule a job that deactivates job posts older than 90 days
- run the job on server startup

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a446bde4832ab70929e6bfc14c21