### PR TITLE
Add pending/onHold status support

### DIFF
--- a/client/src/components/admin/AdminJobDetails.tsx
+++ b/client/src/components/admin/AdminJobDetails.tsx
@@ -118,6 +118,10 @@ export const AdminJobDetails: React.FC = () => {
         return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400";
       case "active":
         return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400";
+      case "pending":
+        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400";
+      case "onHold":
+        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400";
       case "dormant":
         return "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400";
       case "inactive":

--- a/client/src/components/employer/EmployerDashboard.tsx
+++ b/client/src/components/employer/EmployerDashboard.tsx
@@ -202,6 +202,10 @@ export const EmployerDashboard: React.FC = () => {
     switch (status?.toLowerCase()) {
       case 'active':
         return 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
+      case 'pending':
+        return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
+      case 'onhold':
+        return 'bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400';
       case 'dormant':
         return 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400';
       case 'fulfilled':
@@ -215,6 +219,10 @@ export const EmployerDashboard: React.FC = () => {
     switch (status) {
       case 'active':
         return <CheckCircle className="h-4 w-4" />;
+      case 'pending':
+        return <Clock className="h-4 w-4" />;
+      case 'onHold':
+        return <AlertCircle className="h-4 w-4" />;
       case 'dormant':
         return <Clock className="h-4 w-4" />;
       case 'fulfilled':

--- a/client/src/components/employer/EmployerJobs.tsx
+++ b/client/src/components/employer/EmployerJobs.tsx
@@ -56,7 +56,7 @@ interface Job {
   applicationsCount: number;
   createdAt: string;
   updatedAt: string;
-  status?: 'active' | 'dormant' | 'fulfilled';
+  status?: 'active' | 'pending' | 'onHold' | 'dormant' | 'fulfilled' | 'deleted';
   daysSinceCreated?: number;
 }
 
@@ -185,6 +185,10 @@ export const EmployerJobs: React.FC = () => {
     switch (status) {
       case 'active':
         return 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400';
+      case 'pending':
+        return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400';
+      case 'onHold':
+        return 'bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400';
       case 'dormant':
         return 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400';
       case 'fulfilled':
@@ -198,6 +202,10 @@ export const EmployerJobs: React.FC = () => {
     switch (status) {
       case 'active':
         return <CheckCircle className="h-4 w-4" />;
+      case 'pending':
+        return <Clock className="h-4 w-4" />;
+      case 'onHold':
+        return <AlertTriangle className="h-4 w-4" />;
       case 'dormant':
         return <Clock className="h-4 w-4" />;
       case 'fulfilled':
@@ -254,7 +262,7 @@ export const EmployerJobs: React.FC = () => {
             let baseClasses = "border-border transition-colors";
             if (status === 'fulfilled') {
               baseClasses += " bg-green-50 dark:bg-green-950/20 hover:bg-green-100 dark:hover:bg-green-950/30";
-            } else if (status === 'dormant') {
+            } else if (status === 'dormant' || status === 'onHold' || status === 'pending') {
               baseClasses += " bg-red-50 dark:bg-red-950/20 hover:bg-red-100 dark:hover:bg-red-950/30";
             } else {
               baseClasses += " bg-card hover:bg-accent/50 dark:hover:bg-accent/20";
@@ -316,7 +324,7 @@ export const EmployerJobs: React.FC = () => {
                             {markAsFulfilledMutation.isPending ? 'Marking...' : 'Mark as Fulfilled'}
                           </DropdownMenuItem>
                         )}
-                        {status === 'dormant' && (
+                        {['dormant', 'pending', 'onHold'].includes(status) && (
                           <DropdownMenuItem onClick={() => activateJobMutation.mutate(job.id)}>
                             <RotateCcw className="h-4 w-4 mr-2" />
                             Activate Job
@@ -333,7 +341,7 @@ export const EmployerJobs: React.FC = () => {
                   {getStatusIcon(status)}
                   <span className="ml-1 capitalize">{status}</span>
                 </Badge>
-                {status === 'dormant' && (
+                {['dormant', 'pending', 'onHold'].includes(status) && (
                   <Badge variant="outline" className="border-orange-500 text-orange-500">
                     {daysSinceCreated}+ days old
                   </Badge>
@@ -420,6 +428,8 @@ export const EmployerJobs: React.FC = () => {
                 <SelectContent>
                   <SelectItem value="all">All Jobs</SelectItem>
                   <SelectItem value="active">Active</SelectItem>
+                  <SelectItem value="pending">Pending</SelectItem>
+                  <SelectItem value="onHold">On Hold</SelectItem>
                   <SelectItem value="dormant">Dormant</SelectItem>
                   <SelectItem value="fulfilled">Fulfilled</SelectItem>
                 </SelectContent>
@@ -489,6 +499,8 @@ export const EmployerJobs: React.FC = () => {
               </span>
               <div className="flex gap-4">
                 <span>Active: {jobs.filter((j: Job) => getJobStatus(j) === 'active').length || 0}</span>
+                <span>Pending: {jobs.filter((j: Job) => getJobStatus(j) === 'pending').length || 0}</span>
+                <span>On Hold: {jobs.filter((j: Job) => getJobStatus(j) === 'onHold').length || 0}</span>
                 <span>Dormant: {jobs.filter((j: Job) => getJobStatus(j) === 'dormant').length || 0}</span>
                 <span>Fulfilled: {jobs.filter((j: Job) => getJobStatus(j) === 'fulfilled').length || 0}</span>
               </div>

--- a/client/src/components/employer/JobDetails.tsx
+++ b/client/src/components/employer/JobDetails.tsx
@@ -193,6 +193,10 @@ export const JobDetails: React.FC = () => {
         return "bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400";
       case 'active':
         return "bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-400";
+      case 'pending':
+        return "bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-400";
+      case 'onHold':
+        return "bg-gray-100 dark:bg-gray-900/30 text-gray-800 dark:text-gray-400";
       case 'dormant':
         return "bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400";
       case 'inactive':

--- a/shared/utils/jobStatus.ts
+++ b/shared/utils/jobStatus.ts
@@ -1,7 +1,37 @@
-export type JobStatus = 'active' | 'dormant' | 'fulfilled' | 'deleted';
+export type JobStatus =
+  | 'active'
+  | 'pending'
+  | 'onHold'
+  | 'dormant'
+  | 'fulfilled'
+  | 'deleted';
 
-export function getJobStatus({ isActive, fulfilled, deleted }: { isActive?: boolean; fulfilled?: boolean; deleted?: boolean; }): JobStatus {
+export function getJobStatus({
+  isActive,
+  fulfilled,
+  deleted,
+  onHold,
+  createdAt,
+}: {
+  isActive?: boolean;
+  fulfilled?: boolean;
+  deleted?: boolean;
+  onHold?: boolean;
+  createdAt?: Date | string;
+}): JobStatus {
   if (deleted) return 'deleted';
   if (fulfilled) return 'fulfilled';
-  return isActive ? 'active' : 'dormant';
+  if (isActive) return 'active';
+  if (onHold) return 'onHold';
+  if (isActive === false) {
+    if (createdAt) {
+      const createdDate = new Date(createdAt);
+      if (!isNaN(createdDate.getTime())) {
+        const daysSinceCreated =
+          (Date.now() - createdDate.getTime()) / (1000 * 60 * 60 * 24);
+        if (daysSinceCreated < 90) return 'pending';
+      }
+    }
+  }
+  return 'dormant';
 }


### PR DESCRIPTION
## Summary
- extend job statuses with `pending` and `onHold`
- display new statuses in employer dashboards and job lists
- handle new statuses in admin job view

## Testing
- `npm run check`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ab87b544832a9571a185e57510dd