### PR TITLE
Enable soft-delete visibility for admins

### DIFF
--- a/server/repositories/JobRepository.ts
+++ b/server/repositories/JobRepository.ts
@@ -16,6 +16,14 @@ export class JobRepository {
     return jobPost ? { ...jobPost, status: getJobStatus(jobPost) } : undefined;
   }
 
+  static async getJobPostIncludingDeleted(id: number): Promise<(JobPost & { status: string }) | undefined> {
+    const [jobPost] = await db
+      .select()
+      .from(jobPosts)
+      .where(eq(jobPosts.id, id));
+    return jobPost ? { ...jobPost, status: getJobStatus(jobPost) } : undefined;
+  }
+
   static async createJobPost(insertJobPost: InsertJobPost): Promise<JobPost & { status: string }> {
     const [jobPost] = await db
       .insert(jobPosts)
@@ -47,7 +55,10 @@ export class JobRepository {
   }
 
   static async getAllJobPosts(): Promise<(JobPost & { status: string })[]> {
-      const jobs = await db.select().from(jobPosts);
+      const jobs = await db
+        .select()
+        .from(jobPosts)
+        .where(eq(jobPosts.deleted, false));
       return jobs.map((j: JobPost) => ({ ...j, status: getJobStatus(j) }));
   }
 

--- a/server/repositories/__tests__/JobRepository.test.ts
+++ b/server/repositories/__tests__/JobRepository.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { JobRepository } from '../JobRepository';
 
 
 var whereMock: any;
-var data: any[] = [];
 var callIndex = 0;
 
 vi.mock('../../db', () => {
-  data = [
+
+  const data = [
     { id: 1, employerId: 1, isActive: false, deleted: false },
     { id: 2, employerId: 1, isActive: false, deleted: true },
     { id: 3, employerId: 2, isActive: false, deleted: false },
@@ -15,10 +14,13 @@ vi.mock('../../db', () => {
   whereMock = vi.fn(() => {
     const current = callIndex++;
     let result;
+
     if (current === 0) {
       result = data.filter((j) => j.employerId === 1 && !j.deleted);
-    } else {
+    } else if (current === 1) {
       result = data.filter((j) => !j.isActive && !j.deleted);
+    } else {
+      result = data.filter((j) => !j.deleted);
     }
     return result;
   });
@@ -28,6 +30,7 @@ vi.mock('../../db', () => {
 });
 
 import { whereMock as dbWhereMock } from '../../db';
+import { JobRepository } from '../JobRepository';
 
 describe('JobRepository soft delete filters', () => {
   beforeEach(() => {
@@ -42,6 +45,11 @@ describe('JobRepository soft delete filters', () => {
 
   it('getInactiveJobs should filter deleted jobs', async () => {
     const jobs = await JobRepository.getInactiveJobs();
+    expect(jobs.every(j => !j.deleted)).toBe(true);
+  });
+
+  it('getAllJobPosts should filter deleted jobs', async () => {
+    const jobs = await JobRepository.getAllJobPosts();
     expect(jobs.every(j => !j.deleted)).toBe(true);
   });
 });

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -101,7 +101,7 @@ adminRouter.get('/jobs/:id', authenticateUser, asyncHandler(async (req: any, res
     return res.status(403).json({ message: 'Access denied' });
   }
   const jobId = parseInt(req.params.id);
-  const job = await storage.getJobPost(jobId);
+  const job = await storage.getJobPostIncludingDeleted(jobId);
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
   }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -65,6 +65,7 @@ export interface IStorage {
   // Job post operations
 
   getJobPost(id: number): Promise<(JobPost & { status: string }) | undefined>;
+  getJobPostIncludingDeleted(id: number): Promise<(JobPost & { status: string }) | undefined>;
   createJobPost(jobPost: InsertJobPost): Promise<JobPost & { status: string }>;
   updateJobPost(id: number, updates: Partial<JobPost>): Promise<JobPost & { status: string }>;
   getJobPostsByEmployer(employerId: number): Promise<(JobPost & { status: string })[]>;
@@ -229,6 +230,10 @@ export class DatabaseStorage implements IStorage {
     return JobRepository.getJobPost(id);
   }
 
+  async getJobPostIncludingDeleted(id: number): Promise<(JobPost & { status: string }) | undefined> {
+    return JobRepository.getJobPostIncludingDeleted(id);
+  }
+
   async createJobPost(insertJobPost: InsertJobPost): Promise<JobPost & { status: string }> {
     return JobRepository.createJobPost(insertJobPost);
   }
@@ -242,7 +247,8 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllJobPosts(): Promise<(JobPost & { status: string })[]> {
-    return JobRepository.getAllJobPosts();
+    const jobs = await JobRepository.getAllJobPosts();
+    return jobs.filter(job => !job.deleted);
   }
 
   async getInactiveJobPosts(): Promise<(JobPost & { status: string })[]> {


### PR DESCRIPTION
## Summary
- filter out deleted jobs by default in `JobRepository.getAllJobPosts`
- expose `getJobPostIncludingDeleted` in repository and storage
- update admin job view to allow showing deleted jobs
- adjust tests for new behaviour

## Testing
- `npx vitest run --root ./server`

------
https://chatgpt.com/codex/tasks/task_e_6851b260e94c832a8b934316820a683e