### PR TITLE
Implement admin endpoints for job creation and cloning

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -5,6 +5,7 @@ import { asyncHandler } from '../utils/asyncHandler';
 import { validateQuery } from '../middleware/validation';
 import { z } from 'zod';
 import { AdminRepository } from '../repositories';
+import { JobRepository } from '../repositories/JobRepository';
 import { calculateMatchScore } from '../utils/matchingEngine';
 import { exportToExcel, exportToPDF } from '../utils/exportUtils';
 import { storage } from '../storage';
@@ -75,6 +76,20 @@ adminRouter.get('/jobs', authenticateUser, asyncHandler(async (req: any, res) =>
   res.json(jobs);
 }));
 
+adminRouter.post('/jobs', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const jobData = insertJobPostSchema.parse(req.body) as InsertJobPost;
+  const employer = await storage.getEmployer(jobData.employerId);
+  if (!employer || employer.profileStatus !== 'verified') {
+    return res.status(400).json({ message: 'Employer not verified' });
+  }
+  const jobPost = await JobRepository.createJobPost(jobData);
+  res.status(201).json(jobPost);
+}));
+
 /**
  * @swagger
  * /api/admin/jobs/{id}:
@@ -135,6 +150,30 @@ adminRouter.patch('/jobs/:id/fulfill', authenticateUser, asyncHandler(async (req
   }
   const fulfilledJob = await storage.markJobAsFulfilled(jobId);
   res.json(fulfilledJob);
+}));
+
+adminRouter.post('/jobs/:id/clone', authenticateUser, asyncHandler(async (req: any, res) => {
+  const user = await storage.getUserByFirebaseUid(req.user.uid);
+  if (!user || user.role !== 'admin') {
+    return res.status(403).json({ message: 'Access denied' });
+  }
+  const jobId = parseInt(req.params.id);
+  const { employerId } = req.body;
+  if (!employerId) {
+    return res.status(400).json({ message: 'Missing employerId' });
+  }
+  const employer = await storage.getEmployer(employerId);
+  if (!employer || employer.profileStatus !== 'verified') {
+    return res.status(400).json({ message: 'Employer not verified' });
+  }
+  const job = await storage.getJobPost(jobId);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const jobCode = `JOB-${Date.now()}-${Math.random().toString(36).substr(2, 4).toUpperCase()}`;
+  const cloneData = { ...job, title: `Copy of ${job.title}`, employerId: employer.id, jobCode, isActive: false } as InsertJobPost;
+  const clonedJob = await JobRepository.createJobPost(cloneData);
+  res.json(clonedJob);
 }));
 
 /**


### PR DESCRIPTION
## Summary
- allow admins to create job posts for verified employers
- enable admins to clone existing jobs for employers

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b31f17c0832abac8c343752f617a