### PR TITLE
Add job transition validation

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -11,6 +11,7 @@ import { storage } from '../storage';
 import { insertShortlistSchema, insertJobPostSchema } from '@shared/zod';
 import type { InsertJobPost } from '@shared/types';
 import { verifyFirebaseToken } from '../utils/firebase-admin';
+import { validateJobTransition } from '../utils/jobTransitions';
 
 // Validation schemas
 const searchQuerySchema = z.object({
@@ -132,6 +133,10 @@ adminRouter.patch('/jobs/:id/fulfill', authenticateUser, asyncHandler(async (req
   const job = await storage.getJobPost(jobId);
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
+  }
+  const { allowed, message } = validateJobTransition(job, 'fulfill');
+  if (!allowed) {
+    return res.status(400).json({ message });
   }
   const fulfilledJob = await storage.markJobAsFulfilled(jobId);
   res.json(fulfilledJob);
@@ -361,8 +366,16 @@ adminRouter.delete('/jobs/:id', authenticateUser, asyncHandler(async (req: any, 
     return res.status(403).json({ message: 'Access denied' });
   }
   const id = parseInt(req.params.id);
-  const job = await storage.softDeleteJobPost(id);
-  res.json(job);
+  const job = await storage.getJobPost(id);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const { allowed, message } = validateJobTransition(job, 'delete');
+  if (!allowed) {
+    return res.status(400).json({ message });
+  }
+  const deletedJob = await storage.softDeleteJobPost(id);
+  res.json(deletedJob);
 }));
 
 adminRouter.patch('/jobs/:id/approve', authenticateUser, asyncHandler(async (req: any, res) => {
@@ -371,8 +384,16 @@ adminRouter.patch('/jobs/:id/approve', authenticateUser, asyncHandler(async (req
     return res.status(403).json({ message: 'Access denied' });
   }
   const id = parseInt(req.params.id);
-  const job = await storage.approveJob(id);
-  res.json(job);
+  const job = await storage.getJobPost(id);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const { allowed, message } = validateJobTransition(job, 'approve');
+  if (!allowed) {
+    return res.status(400).json({ message });
+  }
+  const updated = await storage.approveJob(id);
+  res.json(updated);
 }));
 
 adminRouter.patch('/jobs/:id/reject', authenticateUser, asyncHandler(async (req: any, res) => {
@@ -381,8 +402,16 @@ adminRouter.patch('/jobs/:id/reject', authenticateUser, asyncHandler(async (req:
     return res.status(403).json({ message: 'Access denied' });
   }
   const id = parseInt(req.params.id);
-  const job = await storage.softDeleteJobPost(id);
-  res.json(job);
+  const job = await storage.getJobPost(id);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const { allowed, message } = validateJobTransition(job, 'reject');
+  if (!allowed) {
+    return res.status(400).json({ message });
+  }
+  const deleted = await storage.softDeleteJobPost(id);
+  res.json(deleted);
 }));
 
 adminRouter.patch('/jobs/:id/hold', authenticateUser, asyncHandler(async (req: any, res) => {
@@ -391,8 +420,16 @@ adminRouter.patch('/jobs/:id/hold', authenticateUser, asyncHandler(async (req: a
     return res.status(403).json({ message: 'Access denied' });
   }
   const id = parseInt(req.params.id);
-  const job = await storage.holdJob(id);
-  res.json(job);
+  const job = await storage.getJobPost(id);
+  if (!job) {
+    return res.status(404).json({ message: 'Job not found' });
+  }
+  const { allowed, message } = validateJobTransition(job, 'hold');
+  if (!allowed) {
+    return res.status(400).json({ message });
+  }
+  const updated = await storage.holdJob(id);
+  res.json(updated);
 }));
 
 adminRouter.get('/candidates', authenticateUser, asyncHandler(async (req: any, res) => {

--- a/server/utils/jobTransitions.ts
+++ b/server/utils/jobTransitions.ts
@@ -1,0 +1,49 @@
+export type JobTransition =
+  | 'activate'
+  | 'deactivate'
+  | 'fulfill'
+  | 'delete'
+  | 'approve'
+  | 'reject'
+  | 'hold';
+
+export interface JobFlags {
+  isActive?: boolean;
+  fulfilled?: boolean;
+  deleted?: boolean;
+}
+
+export function validateJobTransition(job: JobFlags, action: JobTransition): { allowed: boolean; message?: string } {
+  if (job.deleted) {
+    return { allowed: false, message: 'Job has been deleted' };
+  }
+  if (job.fulfilled) {
+    return { allowed: false, message: 'Job has already been fulfilled' };
+  }
+
+  if (action === 'activate' || action === 'approve') {
+    if (job.isActive) {
+      return { allowed: false, message: 'Job is already active' };
+    }
+  }
+
+  if (action === 'deactivate' || action === 'hold') {
+    if (job.isActive === false) {
+      return { allowed: false, message: 'Job is already inactive' };
+    }
+  }
+
+  if (action === 'fulfill') {
+    if (job.fulfilled) {
+      return { allowed: false, message: 'Job is already fulfilled' };
+    }
+  }
+
+  if (action === 'delete' || action === 'reject') {
+    if (job.deleted) {
+      return { allowed: false, message: 'Job is already deleted' };
+    }
+  }
+
+  return { allowed: true };
+}


### PR DESCRIPTION
## Summary
- create `validateJobTransition` util to ensure job state is valid
- guard employer activation and fulfillment routes
- guard admin job status endpoints against deleted or fulfilled jobs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b2ff565c832a80d2beee56121bd6