### PR TITLE
Refactor status checks

### DIFF
--- a/client/src/components/admin/AdminJobDetails.tsx
+++ b/client/src/components/admin/AdminJobDetails.tsx
@@ -176,7 +176,7 @@ export const AdminJobDetails: React.FC = () => {
                 Edit Job
               </Link>
             </DropdownMenuItem>
-            {!job.fulfilled && (
+            {getJobStatus(job) !== 'fulfilled' && (
               <DropdownMenuItem onClick={() => fulfillMutation.mutate()} disabled={fulfillMutation.isPending}>
                 <CheckCircle className="h-4 w-4 mr-2" />
                 {fulfillMutation.isPending ? 'Marking...' : 'Mark as Fulfilled'}

--- a/client/src/components/admin/AdminJobEdit.tsx
+++ b/client/src/components/admin/AdminJobEdit.tsx
@@ -155,7 +155,7 @@ export const AdminJobEdit: React.FC = () => {
   }
 
   // Check if job is fulfilled and prevent editing
-  if (job.fulfilled) {
+  if (getJobStatus(job) === 'fulfilled') {
     return (
       <div className="max-w-4xl mx-auto">
         <Card>

--- a/client/src/components/employer/EmployerDashboard.tsx
+++ b/client/src/components/employer/EmployerDashboard.tsx
@@ -234,16 +234,22 @@ export const EmployerDashboard: React.FC = () => {
 
   const getActiveJobs = () => {
     if (!allJobs) return [];
-    return allJobs.filter((job: any) => job.isActive === true && !job.fulfilled).sort((a: any, b: any) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+    return allJobs
+      .filter((job: any) => getJobStatus(job) === 'active')
+      .sort(
+        (a: any, b: any) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
   };
 
   const getRecentJobs = () => {
     if (!recentJobs) return [];
-    return recentJobs.filter((job: any) => !job.fulfilled).sort((a: any, b: any) => 
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    );
+    return recentJobs
+      .filter((job: any) => getJobStatus(job) !== 'fulfilled')
+      .sort(
+        (a: any, b: any) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
   };
 
   const getCardContent = () => {
@@ -427,7 +433,7 @@ export const EmployerDashboard: React.FC = () => {
                                 {markAsFulfilledMutation.isPending ? "Marking..." : "Mark as Fulfilled"}
                               </DropdownMenuItem>
                             )}
-                            {!job.isActive && (
+                            {status !== 'active' && (
                               <DropdownMenuItem>
                                 <RotateCcw className="h-4 w-4 mr-2" />
                                 Activate Job

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -155,7 +155,7 @@ export const EmployerJobEdit: React.FC = () => {
   }
 
   // Check if job is fulfilled and prevent editing
-  if (job.fulfilled) {
+  if (getJobStatus(job) === 'fulfilled') {
     return (
       <div className="max-w-4xl mx-auto">
         <Card>

--- a/client/src/components/employer/JobDetails.tsx
+++ b/client/src/components/employer/JobDetails.tsx
@@ -49,6 +49,8 @@ export const JobDetails: React.FC = () => {
     enabled: !!id,
   });
 
+  const status = job ? getJobStatus(job) : undefined;
+
   const { data: applications = [], isLoading: applicationsLoading } = useQuery<Application[]>({
     queryKey: [`/api/jobs/${id}/applications`],
     enabled: !!id,
@@ -243,8 +245,8 @@ export const JobDetails: React.FC = () => {
         </div>
         
         <div className="flex items-center gap-2">
-          <Badge className={getStatusColor(getJobStatus(job))}>
-            {getJobStatus(job)}
+          <Badge className={getStatusColor(status || '')}>
+            {status}
           </Badge>
           
           <DropdownMenu>
@@ -254,7 +256,7 @@ export const JobDetails: React.FC = () => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {!job.fulfilled ? (
+              {status !== 'fulfilled' ? (
                 <DropdownMenuItem asChild>
                   <Link href={`/jobs/${job.id}/edit`}>
                     <Edit className="h-4 w-4 mr-2" />
@@ -266,8 +268,8 @@ export const JobDetails: React.FC = () => {
                 <Copy className="h-4 w-4 mr-2" />
                 Clone Job
               </DropdownMenuItem>
-              {job.isActive && !job.fulfilled ? (
-                <DropdownMenuItem 
+              {status === 'active' ? (
+                <DropdownMenuItem
                   onClick={handleFulfillJob}
                   disabled={fulfillJobMutation.isPending}
                 >
@@ -275,8 +277,8 @@ export const JobDetails: React.FC = () => {
                   {fulfillJobMutation.isPending ? "Marking as Fulfilled..." : "Mark as Fulfilled"}
                 </DropdownMenuItem>
               ) : null}
-              {!job.isActive && !job.fulfilled ? (
-                <DropdownMenuItem 
+              {status && status !== 'active' && status !== 'fulfilled' ? (
+                <DropdownMenuItem
                   onClick={handleActivateJob}
                   disabled={activateJobMutation.isPending}
                 >
@@ -396,7 +398,7 @@ export const JobDetails: React.FC = () => {
       </div>
 
       {/* Applications Section - Hidden when job is fulfilled */}
-      {!job?.fulfilled && (
+      {status !== 'fulfilled' && (
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between">

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { insertJobPostSchema } from '@shared/zod';
 import type { InsertJobPost } from '@shared/types';
+import { getJobStatus } from '@shared/utils/jobStatus';
 import { authenticateUser } from '../middleware/authenticate';
 import { requireRole } from '../middleware/authorization';
 import { requireVerifiedRole } from '../middleware/verifiedRole';
@@ -66,7 +67,7 @@ jobsRouter.patch(
     if (!job || (job as any).employerId !== employer.id) {
       return res.status(404).json({ message: 'Job not found' });
     }
-    if (job.fulfilled) {
+    if (getJobStatus(job) === 'fulfilled') {
       return res.status(400).json({ message: 'Cannot activate a fulfilled job' });
     }
     const activatedJob = await storage.activateJob(jobId);
@@ -84,7 +85,7 @@ jobsRouter.patch(
     if (!job || (job as any).employerId !== employer.id) {
       return res.status(404).json({ message: 'Job not found' });
     }
-    if (job.fulfilled) {
+    if (getJobStatus(job) === 'fulfilled') {
       return res.status(400).json({ message: 'Cannot deactivate a fulfilled job' });
     }
     const deactivatedJob = await storage.deactivateJob(jobId);
@@ -131,7 +132,7 @@ jobsRouter.put(
     if (!job) {
       return res.status(404).json({ message: 'Job not found' });
     }
-    if (job.fulfilled) {
+    if (getJobStatus(job) === 'fulfilled') {
       return res.status(403).json({ message: 'Cannot edit fulfilled jobs' });
     }
     if ((job as any).employerId !== employer.id) {

--- a/server/utils/exportUtils.ts
+++ b/server/utils/exportUtils.ts
@@ -1,4 +1,5 @@
 import ExcelJS from "exceljs";
+import { getJobStatus } from "@shared/utils/jobStatus";
 
 export async function exportToExcel(data: any): Promise<Buffer> {
   const workbook = new ExcelJS.Workbook();
@@ -76,7 +77,7 @@ export async function exportToExcel(data: any): Promise<Buffer> {
     { header: 'Salary Range', key: 'salaryRange', width: 15 },
     { header: 'Location', key: 'location', width: 20 },
     { header: 'Applications Count', key: 'applicationsCount', width: 18 },
-    { header: 'Is Active', key: 'isActive', width: 10 },
+    { header: 'Status', key: 'status', width: 10 },
     { header: 'Created At', key: 'createdAt', width: 20 },
   ];
 
@@ -92,7 +93,7 @@ export async function exportToExcel(data: any): Promise<Buffer> {
       salaryRange: job.salaryRange || 'Not specified',
       location: job.location || 'Not specified',
       applicationsCount: job.applicationsCount || 0,
-      isActive: job.isActive ? 'Yes' : 'No',
+      status: getJobStatus(job),
       createdAt: job.createdAt?.toISOString() || 'Unknown',
     });
   });
@@ -178,7 +179,7 @@ ${index + 1}. ${job.title || 'Unknown Title'} (${job.jobCode || 'No Code'})
    Salary: ${job.salaryRange || 'Not specified'}
    Location: ${job.location || 'Not specified'}
    Applications: ${job.applicationsCount || 0}
-   Status: ${job.isActive ? 'Active' : 'Inactive'}
+   Status: ${getJobStatus(job)}
    Created: ${job.createdAt?.toISOString() || 'Unknown'}
 `).join('')}
 


### PR DESCRIPTION
## Summary
- use `getJobStatus` in dashboards and job details
- gate edit screens with status helper
- prevent employer actions when status is fulfilled
- export jobs with unified status output

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b3953cf0832a81a33b12c8ece1b3