### PR TITLE
Prevent edits to deleted jobs

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -134,6 +134,9 @@ adminRouter.put('/jobs/:id', authenticateUser, asyncHandler(async (req: any, res
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
   }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
+  }
   const updateData = insertJobPostSchema.partial().parse(req.body) as Partial<InsertJobPost>;
   const updatedJob = await storage.updateJobPost(jobId, updateData);
   res.json(updatedJob);
@@ -148,6 +151,9 @@ adminRouter.patch('/jobs/:id/fulfill', authenticateUser, asyncHandler(async (req
   const job = await storage.getJobPost(jobId);
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
   }
   const { allowed, message } = validateJobTransition(job, 'fulfill');
   if (!allowed) {
@@ -409,6 +415,9 @@ adminRouter.delete('/jobs/:id', authenticateUser, asyncHandler(async (req: any, 
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
   }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
+  }
   const { allowed, message } = validateJobTransition(job, 'delete');
   if (!allowed) {
     return res.status(400).json({ message });
@@ -426,6 +435,9 @@ adminRouter.patch('/jobs/:id/approve', authenticateUser, asyncHandler(async (req
   const job = await storage.getJobPost(id);
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
   }
   const { allowed, message } = validateJobTransition(job, 'approve');
   if (!allowed) {
@@ -445,6 +457,9 @@ adminRouter.patch('/jobs/:id/reject', authenticateUser, asyncHandler(async (req:
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
   }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
+  }
   const { allowed, message } = validateJobTransition(job, 'reject');
   if (!allowed) {
     return res.status(400).json({ message });
@@ -462,6 +477,9 @@ adminRouter.patch('/jobs/:id/hold', authenticateUser, asyncHandler(async (req: a
   const job = await storage.getJobPost(id);
   if (!job) {
     return res.status(404).json({ message: 'Job not found' });
+  }
+  if (job.deleted) {
+    return res.status(400).json({ message: 'Cannot edit a deleted job post' });
   }
   const { allowed, message } = validateJobTransition(job, 'hold');
   if (!allowed) {

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -141,6 +141,9 @@ jobsRouter.put(
     if (job.fulfilled) {
       return res.status(403).json({ message: 'Cannot edit fulfilled jobs' });
     }
+    if (job.deleted) {
+      return res.status(400).json({ message: 'Cannot edit a deleted job post' });
+    }
     if ((job as any).employerId !== employer.id) {
       return res.status(403).json({ message: 'Access denied' });
     }


### PR DESCRIPTION
## Summary
- block edits on deleted jobs for employers and admins

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6851b64d8104832a8c54edb0e523cdf2