### PR TITLE
Fix job activation and search filtering

### DIFF
--- a/server/repositories/AdminRepository.ts
+++ b/server/repositories/AdminRepository.ts
@@ -90,7 +90,8 @@ export class AdminRepository {
           totalJobs: sql<number>`count(*)`,
           activeJobs: sql<number>`sum(case when job_status = 'ACTIVE' then 1 else 0 end)`
         })
-        .from(jobPosts);
+        .from(jobPosts)
+        .where(eq(jobPosts.deleted, false));
 
       return {
         users: userStats,
@@ -134,7 +135,12 @@ export class AdminRepository {
       const results = await db
         .select()
         .from(jobPosts)
-        .where(sql`to_tsvector('english', title || ' ' || description) @@ plainto_tsquery('english', ${query})`);
+        .where(
+          and(
+            sql`to_tsvector('english', title || ' ' || description) @@ plainto_tsquery('english', ${query})`,
+            eq(jobPosts.deleted, false)
+          )
+        );
 
       return results.map((r: any) => ({ ...r, type: 'job' }));
     }

--- a/server/routes/jobs.ts
+++ b/server/routes/jobs.ts
@@ -72,6 +72,9 @@ jobsRouter.patch(
     if (!job || (job as any).employerId !== employer.id) {
       return res.status(404).json({ message: 'Job not found' });
     }
+    if (!canPerformAction('employer', job.jobStatus as any, 'activate', job.deleted)) {
+      return res.status(400).json({ message: 'Invalid status transition' });
+    }
     if (!isValidTransition(job.jobStatus as any, 'ACTIVE', job.deleted)) {
       return res.status(400).json({ message: 'Invalid status transition' });
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -394,7 +394,10 @@ export class DatabaseStorage implements IStorage {
   // Admin operations
   async getAdminStats(): Promise<any> {
     const allCandidates = await db.select().from(candidates);
-    const activeJobs = await db.select().from(jobPosts).where(eq(jobPosts.jobStatus, 'ACTIVE'));
+    const activeJobs = await db
+      .select()
+      .from(jobPosts)
+      .where(and(eq(jobPosts.jobStatus, 'ACTIVE'), eq(jobPosts.deleted, false)));
     const allShortlists = await db.select().from(shortlists);
     const matchRate = allCandidates.length > 0 ? Math.floor((allShortlists.length / allCandidates.length) * 100) : 0;
     

--- a/shared/utils/__tests__/jobStatus.test.ts
+++ b/shared/utils/__tests__/jobStatus.test.ts
@@ -21,4 +21,14 @@ describe('canPerformAction role rules', () => {
   it('candidate cannot apply to dormant job', () => {
     expect(canPerformAction('candidate', 'DORMANT', 'apply')).toBe(false);
   });
+
+  it('admin can activate dormant job', () => {
+    expect(canPerformAction('admin', 'DORMANT', 'activate')).toBe(true);
+  });
+
+  it('employer cannot activate pending or on hold job', () => {
+    expect(canPerformAction('employer', 'PENDING', 'activate')).toBe(false);
+    expect(canPerformAction('employer', 'ON_HOLD', 'activate')).toBe(false);
+    expect(canPerformAction('employer', 'DORMANT', 'activate')).toBe(true);
+  });
 });

--- a/shared/utils/jobStatus.ts
+++ b/shared/utils/jobStatus.ts
@@ -91,7 +91,7 @@ export function canPerformAction(
       PENDING: ['delete', 'clone', 'edit', 'activate', 'hold'],
       ON_HOLD: ['delete', 'clone', 'edit', 'activate'],
       ACTIVE: ['delete', 'clone', 'edit', 'fulfill'],
-      DORMANT: ['delete', 'clone'],
+      DORMANT: ['delete', 'clone', 'activate'],
       FULFILLED: ['delete', 'clone', 'activate'],
     };
     return rules[status]?.includes(action) ?? false;


### PR DESCRIPTION
## Summary
- allow admins to activate dormant jobs
- restrict employer job activation to dormant jobs
- filter deleted jobs from admin search and stats
- exclude deleted jobs from admin dashboard stats
- add tests for activation rules

## Testing
- `npx vitest run --root .`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68526d1d8bec832ab3645498f3479276