### PR TITLE
Fix job cards in admin verification

### DIFF
--- a/client/src/components/admin/AdminVerifications.tsx
+++ b/client/src/components/admin/AdminVerifications.tsx
@@ -233,10 +233,10 @@ export const AdminVerifications: React.FC = () => {
           experience: item.experienceRequired,
           city: item.location,
           postedOn: formatDate(item.createdAt),
-        },{submittedInfo}}
+        }}
         actions={actions}
       >
-
+        {submittedInfo}
       </JobCard>
     );
   };


### PR DESCRIPTION
## Summary
- ensure job card details render on the admin verification page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dc757308832a9dc4d6796b59c57f