### PR TITLE
Fix employer registration validation and rename Business Type to Industry

### DIFF
--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -75,7 +75,7 @@ export const AdminEmployerDetails: React.FC = () => {
               <span className="font-medium">{employer.registrationNumber}</span>
             </div>
             <div>
-              <span className="text-muted-foreground">Business Type:</span>{" "}
+              <span className="text-muted-foreground">Industry:</span>{" "}
               <span className="font-medium">{employer.businessType}</span>
             </div>
             <div>

--- a/client/src/components/employer/EmployerProfile.tsx
+++ b/client/src/components/employer/EmployerProfile.tsx
@@ -207,13 +207,13 @@ export const EmployerProfile: React.FC = () => {
               </div>
               
               <div>
-                <Label htmlFor="businessType">Business Type</Label>
-                <Select 
-                  value={editData.businessType || ""} 
+                <Label htmlFor="businessType">Industry</Label>
+                <Select
+                  value={editData.businessType || ""}
                   onValueChange={(value) => setEditData({ ...editData, businessType: value })}
                 >
                   <SelectTrigger className="bg-background border-border">
-                    <SelectValue placeholder="Select business type" />
+                    <SelectValue placeholder="Select industry" />
                   </SelectTrigger>
                   <SelectContent>
                     {industries.map((type) => (
@@ -257,7 +257,7 @@ export const EmployerProfile: React.FC = () => {
                   <p className="font-medium text-foreground">{data.registrationNumber}</p>
                 </div>
                 <div>
-                  <p className="text-sm text-muted-foreground">Business Type</p>
+                  <p className="text-sm text-muted-foreground">Industry</p>
                   <p className="font-medium text-foreground">{data.businessType}</p>
                 </div>
                 <div>

--- a/client/src/components/employer/EmployerRegistration.tsx
+++ b/client/src/components/employer/EmployerRegistration.tsx
@@ -253,13 +253,13 @@ export const EmployerRegistration: React.FC = () => {
               </div>
 
               <div>
-                <Label htmlFor="businessType">Business Type *</Label>
-                <Select 
-                  value={formData.businessType} 
+                <Label htmlFor="businessType">Industry *</Label>
+                <Select
+                  value={formData.businessType}
                   onValueChange={(value) => setFormData({ ...formData, businessType: value })}
                 >
                   <SelectTrigger className="bg-background border-border">
-                    <SelectValue placeholder="Select business type" />
+                    <SelectValue placeholder="Select industry" />
                   </SelectTrigger>
                   <SelectContent>
                     {industries.map((type) => (

--- a/server/utils/exportUtils.ts
+++ b/server/utils/exportUtils.ts
@@ -42,7 +42,7 @@ export async function exportToExcel(data: any): Promise<Buffer> {
     { header: 'ID', key: 'id', width: 10 },
     { header: 'Organization Name', key: 'organizationName', width: 30 },
     { header: 'Registration Number', key: 'registrationNumber', width: 20 },
-    { header: 'Business Type', key: 'businessType', width: 20 },
+    { header: 'Industry', key: 'businessType', width: 20 },
     { header: 'Contact Email', key: 'contactEmail', width: 30 },
     { header: 'Contact Phone', key: 'contactPhone', width: 15 },
     { header: 'Address', key: 'address', width: 40 },
@@ -164,7 +164,7 @@ EMPLOYERS
 ${data.employers.map((employer: any, index: number) => `
 ${index + 1}. ${employer.organizationName || 'Unknown Organization'}
    Registration: ${employer.registrationNumber || 'Not specified'}
-   Business Type: ${employer.businessType || 'Not specified'}
+   Industry: ${employer.businessType || 'Not specified'}
    Profile Status: ${employer.profileStatus}
    Created: ${employer.createdAt?.toISOString() || 'Unknown'}
 `).join('')}

--- a/shared/zod/employers.ts
+++ b/shared/zod/employers.ts
@@ -3,6 +3,7 @@ import { employers } from '../schema';
 
 export const insertEmployerSchema = createInsertSchema(employers).omit({
   id: true,
+  userId: true,
   profileStatus: true,
   deleted: true,
   createdAt: true,


### PR DESCRIPTION
## Summary
- allow POST /employers without userId by omitting the field from validation
- relabel "Business Type" as "Industry" across employer UI and admin views
- update export utilities to use "Industry"

## Testing
- `npx vitest run --root .`

------
https://chatgpt.com/codex/tasks/task_e_685547d0df0c832ab7fd91a0470d2bbe