### PR TITLE
Fix candidate profile validation

### DIFF
--- a/shared/zod/candidates.ts
+++ b/shared/zod/candidates.ts
@@ -3,6 +3,7 @@ import { candidates } from '../schema';
 
 export const insertCandidateSchema = createInsertSchema(candidates).omit({
   id: true,
+  userId: true,
   profileStatus: true,
   deleted: true,
   createdAt: true,


### PR DESCRIPTION
## Summary
- omit `userId` in candidate insert schema so the backend assigns it automatically

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555c782518832a8afbe3462fc8d18b