### PR TITLE
Fix candidate profile route to allow viewing when pending

### DIFF
--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -13,9 +13,14 @@ export const candidatesRouter = Router();
 
 candidatesRouter.get(
   '/profile',
-  ...requireVerifiedRole('candidate'),
+  authenticateUser,
+  requireRole('candidate'),
   asyncHandler(async (req: any, res) => {
-    const candidate = req.candidate;
+    const user = req.dbUser;
+    const candidate = await storage.getCandidateByUserId(user.id);
+    if (!candidate || candidate.deleted) {
+      return res.status(404).json({ message: 'Candidate profile not found' });
+    }
     res.json(candidate);
   })
 );


### PR DESCRIPTION
## Summary
- allow candidate users to access `/candidates/profile` without requiring `verified` status
- fetch candidate record directly for profile endpoint

## Testing
- `npm run test -- --dir .`


------
https://chatgpt.com/codex/tasks/task_e_685561a6d6cc832a8483d7618c1f448f