### PR TITLE
Fix candidate profile view for pending status

### DIFF
--- a/client/src/components/candidate/CandidateProfile.tsx
+++ b/client/src/components/candidate/CandidateProfile.tsx
@@ -10,7 +10,7 @@ export const CandidateProfile: React.FC = () => {
   const { userProfile } = useAuth();
   const { data, isLoading } = useQuery({
     queryKey: ["/api/candidates/profile"],
-    enabled: userProfile?.candidate?.profileStatus === "verified",
+    enabled: !!userProfile?.id,
   });
   const [section, setSection] = useState("personal");
 

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -13,9 +13,14 @@ export const candidatesRouter = Router();
 
 candidatesRouter.get(
   '/profile',
-  ...requireVerifiedRole('candidate'),
+  authenticateUser,
+  requireRole('candidate'),
   asyncHandler(async (req: any, res) => {
-    const candidate = req.candidate;
+    const user = req.dbUser;
+    const candidate = await storage.getCandidateByUserId(user.id);
+    if (!candidate || candidate.deleted) {
+      return res.status(404).json({ message: 'Candidate profile not found' });
+    }
     res.json(candidate);
   })
 );


### PR DESCRIPTION
## Summary
- allow CandidateProfile to fetch profile data for pending candidates

## Testing
- `npm run test -- --dir .`


------
https://chatgpt.com/codex/tasks/task_e_685561a6d6cc832a8483d7618c1f448f