### PR TITLE
Fix candidate status handling

### DIFF
--- a/server/middleware/authorization.ts
+++ b/server/middleware/authorization.ts
@@ -37,6 +37,9 @@ export function ensureProfileVerified(type: 'candidate' | 'employer') {
         if (!candidate || candidate.deleted) {
           return res.status(404).json({ message: 'Candidate profile not found' });
         }
+        if (candidate.profileStatus === 'incomplete') {
+          return res.status(403).json({ message: 'Candidate profile incomplete' });
+        }
         if (candidate.profileStatus !== 'verified') {
           return res.status(403).json({ message: 'Candidate not verified' });
         }

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -36,7 +36,11 @@ candidatesRouter.patch(
     if (!candidate || candidate.id !== parseInt(req.params.id)) {
       return res.status(403).json({ message: 'Access denied' });
     }
-    const updatedCandidate = await CandidateRepository.update(candidate.id, req.body);
+    const updates = { ...req.body };
+    if (candidate.profileStatus === 'verified') {
+      (updates as any).profileStatus = 'pending';
+    }
+    const updatedCandidate = await CandidateRepository.update(candidate.id, updates);
     res.json(updatedCandidate);
   })
 );


### PR DESCRIPTION
## Summary
- allow other APIs to detect incomplete profiles separately from pending status
- reset verified candidate profiles to pending when updated

## Testing
- `npx --yes vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685564b97810832a8866a65c21314ff1