### PR TITLE
Enable candidate job applications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ import { AdminSearchPanel } from "./components/admin/AdminSearchPanel";
 import { AdminVerifications } from "./components/admin/AdminVerifications";
 import { AdminTools } from "./components/admin/AdminTools";
 import { AdminEmployerDetails } from "./components/admin/AdminEmployerDetails";
+import { CandidateJobDetails } from "./components/candidate/CandidateJobDetails";
 import NotFound from "./pages/not-found";
 
 function ProtectedRoute({
@@ -263,6 +264,15 @@ function Router() {
         <Route path="/candidate/jobs">
           <ProtectedRoute roles={["candidate"]}>
             <Dashboard />
+          </ProtectedRoute>
+        </Route>
+        <Route path="/candidate/jobs/:id">
+          <ProtectedRoute roles={["candidate"]}>
+            <div className="min-h-screen bg-background">
+              <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <CandidateJobDetails />
+              </div>
+            </div>
           </ProtectedRoute>
         </Route>
         <Route path="/candidate/register">

--- a/client/src/components/candidate/CandidateJobDetails.tsx
+++ b/client/src/components/candidate/CandidateJobDetails.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { useParams, Link } from "wouter";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, DollarSign, Calendar, ArrowLeft } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+export const CandidateJobDetails: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data: job, isLoading } = useQuery({
+    queryKey: [`/api/candidates/jobs/${id}`],
+    enabled: !!id,
+  });
+
+  const applyMutation = useMutation({
+    mutationFn: async () => {
+      return apiRequest(`/api/candidates/jobs/${id}/apply`, "POST");
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["/api/candidates/applications"] });
+      toast({ title: "Application submitted" });
+    },
+    onError: (error: any) => {
+      toast({ title: "Error", description: error.message, variant: "destructive" });
+    },
+  });
+
+  const handleApply = () => {
+    applyMutation.mutate();
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="animate-pulse bg-card border-border">
+        <CardContent className="p-6 space-y-4">
+          <div className="h-6 bg-muted rounded w-1/3"></div>
+          <div className="h-4 bg-muted rounded w-1/2"></div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!job) {
+    return (
+      <Card>
+        <CardContent className="p-12 text-center space-y-4">
+          <p className="text-muted-foreground">Job not found</p>
+          <Link href="/candidate/jobs">
+            <Button>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Jobs
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl mx-auto">
+      <Link href="/candidate/jobs">
+        <Button variant="outline" size="sm" className="flex items-center gap-1">
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </Button>
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>{job.title}</span>
+            {job.jobCode && (
+              <Badge variant="outline" className="border-border text-xs">
+                {job.jobCode}
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium">{job.location}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <DollarSign className="h-4 w-4 text-muted-foreground" />
+              <span className="text-green-600 dark:text-green-400 font-medium">
+                {job.salaryRange}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              <span>
+                Posted {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="font-semibold mb-2">Job Description</h3>
+            <p className="text-muted-foreground whitespace-pre-line">
+              {job.description || "No description provided."}
+            </p>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              onClick={handleApply}
+              disabled={applyMutation.isLoading}
+              className="bg-primary hover:bg-primary-dark text-primary-foreground"
+            >
+              Apply
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -117,3 +117,18 @@ candidatesRouter.get(
     res.json(rest);
   })
 );
+
+// Submit application for a job
+candidatesRouter.post(
+  '/jobs/:id/apply',
+  ...requireVerifiedRole('candidate'),
+  asyncHandler(async (req: any, res) => {
+    const jobId = parseInt(req.params.id);
+    const candidate = req.candidate;
+    const application = await storage.createApplication({
+      jobPostId: jobId,
+      candidateId: candidate.id,
+    });
+    res.json(application);
+  })
+);


### PR DESCRIPTION
## Summary
- add job details page for candidates with an Apply button
- handle Apply button in candidate job list
- expose route `/candidate/jobs/:id` and new page in router
- add API route to submit job applications

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685615a2641c832aab676f436e2a1513