### PR TITLE
Fix candidate job apply refresh

### DIFF
--- a/client/src/components/candidate/CandidateJobDetails.tsx
+++ b/client/src/components/candidate/CandidateJobDetails.tsx
@@ -40,9 +40,12 @@ export const CandidateJobDetails: React.FC = () => {
       return apiRequest(`/api/candidates/jobs/${id}/apply`, "POST");
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["/api/candidates/applications"] });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/candidates/applications"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/candidates/jobs"] }),
+      ]);
       setApplied(true);
-      toast({ title: "Application submitted" });
+      toast({ title: "Job applied successfully" });
     },
     onError: (error: any) => {
       toast({ title: "Error", description: error.message, variant: "destructive" });

--- a/client/src/components/candidate/CandidateJobs.tsx
+++ b/client/src/components/candidate/CandidateJobs.tsx
@@ -45,8 +45,11 @@ export const CandidateJobs: React.FC = () => {
       return apiRequest(`/api/candidates/jobs/${jobId}/apply`, "POST");
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["/api/candidates/applications"] });
-      toast({ title: "Application submitted" });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["/api/candidates/applications"] }),
+        queryClient.invalidateQueries({ queryKey: ["/api/candidates/jobs"] }),
+      ]);
+      toast({ title: "Job applied successfully" });
     },
     onError: (error: any) => {
       toast({ title: "Error", description: error.message, variant: "destructive" });


### PR DESCRIPTION
## Summary
- refresh candidate job list and applications after applying
- show a "Job applied successfully" toast on success

## Testing
- `npm test --silent` *(fails: no test files)*

------
https://chatgpt.com/codex/tasks/task_e_685621b2b150832a87d8423c78e6a21a