### PR TITLE
Strip company details from candidate APIs

### DIFF
--- a/client/src/components/candidate/CandidateApplications.tsx
+++ b/client/src/components/candidate/CandidateApplications.tsx
@@ -14,7 +14,6 @@ interface Application {
   status: string;
   appliedAt: string;
   jobTitle: string;
-  company: string;
   location: string;
   salaryRange: string;
   jobCode: string;

--- a/client/src/components/candidate/CandidateDashboard.tsx
+++ b/client/src/components/candidate/CandidateDashboard.tsx
@@ -169,7 +169,6 @@ export const CandidateDashboard: React.FC = () => {
                         <h3 className="font-semibold text-lg text-foreground">
                           {job.title}
                         </h3>
-                        <p className="text-muted-foreground">{job.company}</p>
                       </div>
                     </div>
 
@@ -243,7 +242,6 @@ export const CandidateDashboard: React.FC = () => {
                   </div>
                   <div>
                     <h4 className="font-medium text-foreground">{app.jobTitle}</h4>
-                    <p className="text-sm text-muted-foreground">{app.company}</p>
                   </div>
                 </div>
                 <div className="text-right">

--- a/client/src/components/candidate/CandidateJobs.tsx
+++ b/client/src/components/candidate/CandidateJobs.tsx
@@ -22,9 +22,6 @@ interface Job {
   salaryRange: string;
   location: string;
   createdAt: string;
-  employer: {
-    organizationName: string;
-  };
   compatibilityScore?: number;
   matchFactors?: {
     skillsScore: number;

--- a/server/repositories/CandidateRepository.ts
+++ b/server/repositories/CandidateRepository.ts
@@ -1,6 +1,6 @@
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { db } from '../db';
-import { candidates, users, applications, jobPosts, employers } from '@shared/schema';
+import { candidates, users, applications, jobPosts } from '@shared/schema';
 import type { InsertCandidate } from '@shared/types';
 
 /**
@@ -210,14 +210,12 @@ export class CandidateRepository {
         status: applications.status,
         appliedAt: applications.appliedAt,
         jobTitle: jobPosts.title,
-        company: employers.organizationName,
         location: jobPosts.location,
         salaryRange: jobPosts.salaryRange,
         jobCode: jobPosts.jobCode,
       })
       .from(applications)
       .innerJoin(jobPosts, eq(jobPosts.id, applications.jobPostId))
-      .innerJoin(employers, eq(jobPosts.employerId, employers.id))
       .where(eq(applications.candidateId, candidateId))
       .orderBy(desc(applications.appliedAt));
   }

--- a/server/routes/candidates.ts
+++ b/server/routes/candidates.ts
@@ -99,7 +99,8 @@ candidatesRouter.get(
   '/jobs',
   asyncHandler(async (_req, res) => {
     const jobs = await storage.getPublicJobPosts();
-    res.json(jobs);
+    const sanitizedJobs = jobs.map(({ employerId, ...rest }: any) => rest);
+    res.json(sanitizedJobs);
   })
 );
 


### PR DESCRIPTION
## Summary
- sanitize `/jobs` listing to exclude employer data
- omit employer joins when fetching candidate applications
- adjust candidate dashboard and applications UI for missing company info
- update job interface for candidates

## Testing
- `npm run check` *(fails: UserRepository.ts TypeScript errors)*
- `npm test --silent` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68562a2e46cc832a91159b396983edb8