### PR TITLE
Fix client env usage

### DIFF
--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -1,10 +1,8 @@
-import { config } from "dotenv";
-config();
 /**
  * API Configuration
  */
 
-export const API_BASE_URL = process.env.VITE_API_URL || 'http://localhost:3000';
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 /**
  * API Endpoints

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -2,16 +2,14 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
-import { config } from "dotenv";
-config();
 
 const firebaseConfig = {
-  apiKey: process.env.VITE_FIREBASE_API_KEY,
-  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.VITE_FIREBASE_APP_ID,
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
 // Initialize Firebase

--- a/client/src/lib/logger.ts
+++ b/client/src/lib/logger.ts
@@ -1,8 +1,6 @@
-import { config } from "dotenv";
-config();
 
 export const debugLog = (...args: unknown[]) => {
-  if (process.env.DEV) {
+  if (import.meta.env.DEV) {
     console.log(...args);
   }
 };

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -49,7 +49,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,9 @@ config();
 
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+const __dirname = dirname(fileURLToPath(import.meta.url));
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig(async () => {
@@ -16,14 +18,14 @@ export default defineConfig(async () => {
     plugins: [react(), runtimeErrorOverlay(), ...cartographerPlugins],
     resolve: {
       alias: {
-        "@": path.resolve(import.meta.dirname, "client", "src"),
-        "@shared": path.resolve(import.meta.dirname, "shared"),
-        "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+        "@": path.resolve(__dirname, "client", "src"),
+        "@shared": path.resolve(__dirname, "shared"),
+        "@assets": path.resolve(__dirname, "attached_assets"),
       },
     },
-    root: path.resolve(import.meta.dirname, "client"),
+    root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(import.meta.dirname, "dist/public"),
+      outDir: path.resolve(__dirname, "dist/public"),
       emptyOutDir: true,
     },
     envPrefix: "VITE_",


### PR DESCRIPTION
## Summary
- revert unintended dotenv usage in client
- switch back to Vite `import.meta.env` variables

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856cc4a2098832aaa20f9fa18338420