### PR TITLE
Fix Firebase admin fallback

### DIFF
--- a/client/src/config/api.ts
+++ b/client/src/config/api.ts
@@ -1,10 +1,8 @@
-import { config } from "dotenv";
-config();
 /**
  * API Configuration
  */
 
-export const API_BASE_URL = process.env.VITE_API_URL || 'http://localhost:3000';
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 /**
  * API Endpoints

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -2,16 +2,14 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
-import { config } from "dotenv";
-config();
 
 const firebaseConfig = {
-  apiKey: process.env.VITE_FIREBASE_API_KEY,
-  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.VITE_FIREBASE_APP_ID,
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
 // Initialize Firebase

--- a/client/src/lib/logger.ts
+++ b/client/src/lib/logger.ts
@@ -1,8 +1,6 @@
-import { config } from "dotenv";
-config();
 
 export const debugLog = (...args: unknown[]) => {
-  if (process.env.DEV) {
+  if (import.meta.env.DEV) {
     console.log(...args);
   }
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -73,10 +73,9 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
+  // Use PORT from the environment when available (Render etc.)
+  // Default to 5000 for Replit and local development.
+  const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 5000;
   server.listen({
     port,
     host: "0.0.0.0",

--- a/server/utils/firebase-admin.ts
+++ b/server/utils/firebase-admin.ts
@@ -1,46 +1,64 @@
 import { config } from 'dotenv';
 config();
-import admin from "firebase-admin";
+import admin from 'firebase-admin';
 
-// Initialize Firebase Admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp({
+let firebaseApp: admin.app.App | undefined;
+if (
+  process.env.VITE_FIREBASE_PROJECT_ID &&
+  process.env.FIREBASE_PRIVATE_KEY &&
+  process.env.FIREBASE_CLIENT_EMAIL
+) {
+  // Initialize Firebase Admin SDK when credentials are available
+  firebaseApp = admin.initializeApp({
     credential: admin.credential.cert({
       projectId: process.env.VITE_FIREBASE_PROJECT_ID,
-      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      privateKey: process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n'),
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
     }),
   });
+} else {
+  console.warn(
+    'Firebase Admin credentials are missing. Admin features are disabled.'
+  );
 }
 
-export const auth = admin.auth();
-export const firestore = admin.firestore();
-export const storage = admin.storage();
+export const auth = firebaseApp ? admin.auth() : undefined;
+export const firestore = firebaseApp ? admin.firestore() : undefined;
+export const storage = firebaseApp ? admin.storage() : undefined;
 
 export async function verifyFirebaseToken(token: string) {
+  if (!auth) {
+    throw new Error('Firebase Admin not configured');
+  }
   try {
     const decodedToken = await auth.verifyIdToken(token);
     return decodedToken;
   } catch (error) {
-    console.error("Error verifying Firebase token:", error);
-    throw new Error("Invalid Firebase token");
+    console.error('Error verifying Firebase token:', error);
+    throw new Error('Invalid Firebase token');
   }
 }
 
 export async function createCustomToken(uid: string, additionalClaims?: any) {
+  if (!auth) {
+    throw new Error('Firebase Admin not configured');
+  }
   try {
     return await auth.createCustomToken(uid, additionalClaims);
   } catch (error) {
-    console.error("Error creating custom token:", error);
-    throw new Error("Failed to create custom token");
+    console.error('Error creating custom token:', error);
+    throw new Error('Failed to create custom token');
   }
 }
 
 export async function setUserClaims(uid: string, claims: any) {
+  if (!auth) {
+    throw new Error('Firebase Admin not configured');
+  }
   try {
     await auth.setCustomUserClaims(uid, claims);
   } catch (error) {
-    console.error("Error setting user claims:", error);
-    throw new Error("Failed to set user claims");
+    console.error('Error setting user claims:', error);
+    throw new Error('Failed to set user claims');
   }
 }

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -49,7 +49,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        __dirname,
         "..",
         "client",
         "index.html"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,9 @@ config();
 
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+const __dirname = dirname(fileURLToPath(import.meta.url));
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
 export default defineConfig(async () => {
@@ -16,14 +18,14 @@ export default defineConfig(async () => {
     plugins: [react(), runtimeErrorOverlay(), ...cartographerPlugins],
     resolve: {
       alias: {
-        "@": path.resolve(import.meta.dirname, "client", "src"),
-        "@shared": path.resolve(import.meta.dirname, "shared"),
-        "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+        "@": path.resolve(__dirname, "client", "src"),
+        "@shared": path.resolve(__dirname, "shared"),
+        "@assets": path.resolve(__dirname, "attached_assets"),
       },
     },
-    root: path.resolve(import.meta.dirname, "client"),
+    root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(import.meta.dirname, "dist/public"),
+      outDir: path.resolve(__dirname, "dist/public"),
       emptyOutDir: true,
     },
     envPrefix: "VITE_",


### PR DESCRIPTION
## Summary
- handle missing Firebase credentials so server can start without crashing
- bind the server port from `PORT` environment variable when available

## Testing
- `npm test` *(fails: No test files found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856cc4a2098832aaa20f9fa18338420