### PR TITLE
Display uploaded docs on admin detail pages

### DIFF
--- a/client/src/components/admin/AdminCandidateDetails.tsx
+++ b/client/src/components/admin/AdminCandidateDetails.tsx
@@ -130,6 +130,47 @@ export const AdminCandidateDetails: React.FC = () => {
           </div>
         </CardContent>
       </Card>
+
+      {candidate.documents && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Briefcase className="h-5 w-5" />
+              Documents
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {Object.entries(candidate.documents).map(([key, value]) => {
+              try {
+                const doc = JSON.parse(value as unknown as string);
+                return (
+                  <div key={key} className="flex items-center justify-between">
+                    <span className="capitalize text-muted-foreground">{key}:</span>
+                    {doc?.data ? (
+                      <a
+                        href={doc.data}
+                        download={doc.name || `${key}.pdf`}
+                        className="text-primary hover:underline"
+                      >
+                        Download {doc.name || key}
+                      </a>
+                    ) : (
+                      <span className="font-medium">{doc?.name || 'N/A'}</span>
+                    )}
+                  </div>
+                );
+              } catch {
+                return (
+                  <div key={key} className="flex items-center justify-between">
+                    <span className="capitalize text-muted-foreground">{key}:</span>
+                    <span className="font-medium">{value as string}</span>
+                  </div>
+                );
+              }
+            })}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 };

--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -93,6 +93,47 @@ export const AdminEmployerDetails: React.FC = () => {
           </div>
         </CardContent>
       </Card>
+
+      {employer.documents && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Building2 className="h-5 w-5" />
+              Documents
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {Object.entries(employer.documents).map(([key, value]) => {
+              try {
+                const doc = JSON.parse(value as unknown as string);
+                return (
+                  <div key={key} className="flex items-center justify-between">
+                    <span className="capitalize text-muted-foreground">{key}:</span>
+                    {doc?.data ? (
+                      <a
+                        href={doc.data}
+                        download={doc.name || `${key}.pdf`}
+                        className="text-primary hover:underline"
+                      >
+                        Download {doc.name || key}
+                      </a>
+                    ) : (
+                      <span className="font-medium">{doc?.name || 'N/A'}</span>
+                    )}
+                  </div>
+                );
+              } catch {
+                return (
+                  <div key={key} className="flex items-center justify-between">
+                    <span className="capitalize text-muted-foreground">{key}:</span>
+                    <span className="font-medium">{value as string}</span>
+                  </div>
+                );
+              }
+            })}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- show candidate documents with download links on admin candidate detail page
- show employer documents with download links on admin employer detail page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8dc836a8832abae4971fbd6520de