### PR TITLE
Fix active jobs count

### DIFF
--- a/server/repositories/AdminRepository.ts
+++ b/server/repositories/AdminRepository.ts
@@ -88,7 +88,7 @@ export class AdminRepository {
       const [jobStats] = await tx
         .select({
           totalJobs: sql<number>`count(*)`,
-          activeJobs: sql<number>`sum(case when job_status = 'ACTIVE' then 1 else 0 end)`
+          activeJobs: sql<number>`sum(case when job_status in ('ACTIVE', 'ON_HOLD') then 1 else 0 end)`
         })
         .from(jobPosts)
         .where(eq(jobPosts.deleted, false));


### PR DESCRIPTION
## Summary
- include ON_HOLD jobs when counting active jobs for admin stats

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb19430e4832ab11491a9f126869a