### PR TITLE
Fix admin stats not reloading

### DIFF
--- a/client/src/components/admin/AdminDashboard.tsx
+++ b/client/src/components/admin/AdminDashboard.tsx
@@ -9,6 +9,8 @@ import { debugLog } from "@/lib/logger";
 export const AdminDashboard: React.FC = () => {
   const { data: stats } = useQuery({
     queryKey: ["/api/admin/stats"],
+    staleTime: 0,
+    refetchOnMount: true,
   });
 
 


### PR DESCRIPTION
## Summary
- ensure admin dashboard stats query refetches on mount

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb1bfb810832a9171aeaa59970e44