### PR TITLE
Redirect to detail pages on save

### DIFF
--- a/client/src/components/candidate/CandidateProfileEdit.tsx
+++ b/client/src/components/candidate/CandidateProfileEdit.tsx
@@ -11,7 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { useFileUpload } from "@/hooks/useFileUpload";
 import { genders, maritalStatuses } from "@shared/constants";
 
@@ -36,6 +36,7 @@ export const CandidateProfileEdit: React.FC = () => {
   const { userProfile } = useAuth();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const [, setLocation] = useLocation();
   
   const [editingSection, setEditingSection] = useState<string | null>(null);
   const [editData, setEditData] = useState<any>({});
@@ -60,6 +61,7 @@ export const CandidateProfileEdit: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ["/api/candidates/stats"] });
       setEditingSection(null);
       setEditData({});
+      setLocation("/candidate/profile");
     },
     onError: (error: any) => {
       toast({

--- a/client/src/components/candidate/CandidateRegistration.tsx
+++ b/client/src/components/candidate/CandidateRegistration.tsx
@@ -180,9 +180,9 @@ export const CandidateRegistration: React.FC = () => {
         description: "Profile created successfully!",
       });
       
-      // Refresh profile and navigate to jobs page
+      // Refresh profile and navigate to the newly created profile page
       refreshProfile();
-      setLocation("/candidate/jobs");
+      setLocation("/candidate/profile");
     } catch (error) {
       toast({
         title: "Error",

--- a/client/src/components/employer/EmployerJobCreate.tsx
+++ b/client/src/components/employer/EmployerJobCreate.tsx
@@ -122,14 +122,12 @@ export const EmployerJobCreate: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ["/api/employers/stats"] });
 
       const newJobId = result?.data?.id;
-      if (cloneData && newJobId) {
+      if (newJobId) {
         setLocation(`/jobs/${newJobId}`);
-        return;
+      } else {
+        const targetPage = referrer === 'jobs' ? '/jobs' : '/employer/dashboard';
+        setLocation(targetPage);
       }
-
-      // Navigate back to the referring page
-      const targetPage = referrer === 'jobs' ? '/jobs' : '/employer/dashboard';
-      setLocation(targetPage);
     },
     onError: (error: any) => {
       toast({

--- a/client/src/components/employer/EmployerRegistration.tsx
+++ b/client/src/components/employer/EmployerRegistration.tsx
@@ -55,7 +55,7 @@ export const EmployerRegistration: React.FC = () => {
 
   useEffect(() => {
     if (existingProfile && !checkingProfile) {
-      setLocation("/employer/dashboard");
+      setLocation("/employer/profile");
     }
   }, [existingProfile, checkingProfile, setLocation]);
 
@@ -77,7 +77,7 @@ export const EmployerRegistration: React.FC = () => {
             description: "Redirecting to your existing profile",
           });
           refreshProfile();
-          setLocation("/employer/dashboard");
+          setLocation("/employer/profile");
           return;
         }
         throw error;
@@ -90,7 +90,7 @@ export const EmployerRegistration: React.FC = () => {
         description: "Your employer profile has been created successfully",
       });
       refreshProfile();
-      setLocation("/employer/dashboard");
+      setLocation("/employer/profile");
     },
     onError: (error: any) => {
       console.error("Registration mutation error:", error);
@@ -102,7 +102,7 @@ export const EmployerRegistration: React.FC = () => {
           description: "Redirecting to your existing profile",
         });
         refreshProfile();
-        setLocation("/employer/dashboard");
+        setLocation("/employer/profile");
         return;
       }
       


### PR DESCRIPTION
## Summary
- redirect employer job creation to its new job detail page
- go to candidate profile after registration or edit
- redirect to employer profile after registration

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb23af8e8832a99c7caa9a199c936