### PR TITLE
Add BackButton component and refactor pages

### DIFF
--- a/client/src/components/admin/AdminCandidateDetails.tsx
+++ b/client/src/components/admin/AdminCandidateDetails.tsx
@@ -3,7 +3,8 @@ import { useParams, Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, User, Briefcase } from "lucide-react";
+import { User, Briefcase } from "lucide-react";
+import { BackButton } from "@/components/common";
 
 export const AdminCandidateDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -35,12 +36,7 @@ export const AdminCandidateDetails: React.FC = () => {
             <h3 className="text-lg font-medium text-foreground mb-2">
               Candidate not found
             </h3>
-            <Link href="/admin/tools">
-              <Button>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back
-              </Button>
-            </Link>
+            <BackButton fallback="/admin/dashboard" />
           </CardContent>
         </Card>
       </div>
@@ -50,12 +46,7 @@ export const AdminCandidateDetails: React.FC = () => {
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <div className="flex items-center gap-2">
-        <Link href="/admin/tools">
-          <Button variant="outline" size="sm">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back
-          </Button>
-        </Link>
+        <BackButton fallback="/admin/dashboard" variant="outline" size="sm" />
         <h1 className="text-3xl font-bold text-foreground">Candidate Details</h1>
       </div>
 

--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -3,7 +3,8 @@ import { useParams, Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Building2 } from "lucide-react";
+import { Building2 } from "lucide-react";
+import { BackButton } from "@/components/common";
 
 export const AdminEmployerDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -33,12 +34,7 @@ export const AdminEmployerDetails: React.FC = () => {
         <Card>
           <CardContent className="p-12 text-center">
             <h3 className="text-lg font-medium text-foreground mb-2">Employer not found</h3>
-            <Link href="/admin/tools">
-              <Button>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back
-              </Button>
-            </Link>
+            <BackButton fallback="/admin/dashboard" />
           </CardContent>
         </Card>
       </div>
@@ -48,12 +44,7 @@ export const AdminEmployerDetails: React.FC = () => {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center gap-2">
-        <Link href="/admin/tools">
-          <Button variant="outline" size="sm">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back
-          </Button>
-        </Link>
+        <BackButton fallback="/admin/dashboard" variant="outline" size="sm" />
         <h1 className="text-3xl font-bold text-foreground">Employer Details</h1>
       </div>
 

--- a/client/src/components/admin/AdminJobDetails.tsx
+++ b/client/src/components/admin/AdminJobDetails.tsx
@@ -22,8 +22,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
- import {
-  ArrowLeft,
+import {
   MapPin,
   Calendar,
   Users,
@@ -40,6 +39,7 @@ import {
   Mail,
   Phone,
 } from "lucide-react";
+import { BackButton } from "@/components/common";
 import type { JobPost, Application, Employer } from "@shared/types";
 import { formatDistanceToNow } from "date-fns";
 
@@ -101,12 +101,7 @@ export const AdminJobDetails: React.FC = () => {
         <Card>
           <CardContent className="p-12 text-center">
             <h3 className="text-lg font-medium text-foreground mb-2">Job not found</h3>
-            <Link href="/admin/dashboard">
-              <Button>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back
-              </Button>
-            </Link>
+            <BackButton fallback="/admin/dashboard" />
           </CardContent>
         </Card>
       </div>
@@ -169,12 +164,7 @@ export const AdminJobDetails: React.FC = () => {
   return (
     <div className="max-w-6xl mx-auto space-y-6">
       <div className="flex items-center gap-2">
-        <Link href="/admin/dashboard">
-          <Button variant="outline" size="sm">
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back
-          </Button>
-        </Link>
+        <BackButton fallback="/admin/dashboard" variant="outline" size="sm" />
         <h1 className="text-3xl font-bold text-foreground">{job.title}</h1>
         <Badge className={getStatusColor(getJobStatus(job))}>
           {getStatusIcon(getJobStatus(job))}

--- a/client/src/components/admin/AdminJobEdit.tsx
+++ b/client/src/components/admin/AdminJobEdit.tsx
@@ -12,7 +12,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ArrowLeft, Save } from "lucide-react";
+import { Save } from "lucide-react";
+import { BackButton } from "@/components/common";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -144,10 +145,7 @@ export const AdminJobEdit: React.FC = () => {
             <p className="text-muted-foreground mb-6">
               The job you're trying to edit doesn't exist or has been removed.
             </p>
-            <Button onClick={() => setLocation("/admin/dashboard")}>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Jobs
-            </Button>
+            <BackButton fallback="/admin/dashboard" label="Back to Jobs" />
           </CardContent>
         </Card>
       </div>
@@ -165,10 +163,7 @@ export const AdminJobEdit: React.FC = () => {
               This job has been marked as fulfilled and cannot be edited. You can clone this job to create a new posting.
             </p>
             <div className="flex gap-4 justify-center">
-              <Button onClick={() => setLocation("/admin/dashboard")}>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back to Jobs
-              </Button>
+              <BackButton fallback="/admin/dashboard" label="Back to Jobs" />
             </div>
           </CardContent>
         </Card>
@@ -179,10 +174,7 @@ export const AdminJobEdit: React.FC = () => {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button variant="outline" onClick={() => setLocation("/admin/dashboard")}>
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Jobs
-        </Button>
+        <BackButton fallback="/admin/dashboard" label="Back to Jobs" variant="outline" />
         <div>
           <h1 className="text-3xl font-bold text-foreground">Edit Job</h1>
           <p className="text-muted-foreground">Update job details and requirements</p>

--- a/client/src/components/candidate/CandidateJobDetails.tsx
+++ b/client/src/components/candidate/CandidateJobDetails.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { useParams, Link } from "wouter";
+import { useParams } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { MapPin, Calendar, ArrowLeft, IndianRupee } from "lucide-react";
+import { MapPin, Calendar, IndianRupee } from "lucide-react";
+import { BackButton } from "@/components/common";
 import { formatDistanceToNow } from "date-fns";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -80,12 +81,7 @@ export const CandidateJobDetails: React.FC = () => {
       <Card>
         <CardContent className="p-12 text-center space-y-4">
           <p className="text-muted-foreground">Job not found</p>
-          <Link href="/candidate/jobs">
-            <Button>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Jobs
-            </Button>
-          </Link>
+          <BackButton fallback="/jobs" label="Back to Jobs" />
         </CardContent>
       </Card>
     );
@@ -93,12 +89,12 @@ export const CandidateJobDetails: React.FC = () => {
 
   return (
     <div className="space-y-6 max-w-3xl mx-auto">
-      <Link href="/candidate/jobs">
-        <Button variant="outline" size="sm" className="flex items-center gap-1">
-          <ArrowLeft className="h-4 w-4" />
-          Back
-        </Button>
-      </Link>
+      <BackButton
+        fallback="/jobs"
+        variant="outline"
+        size="sm"
+        className="flex items-center gap-1"
+      />
 
       <Card>
         <CardHeader>

--- a/client/src/components/candidate/CandidateProfileEdit.tsx
+++ b/client/src/components/candidate/CandidateProfileEdit.tsx
@@ -6,12 +6,12 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Edit, Save, X, User, Briefcase, Upload, FileText, Download, GraduationCap, Plus, Minus } from "lucide-react";
+import { Edit, Save, X, User, Briefcase, Upload, FileText, Download, GraduationCap, Plus, Minus } from "lucide-react";
+import { BackButton } from "@/components/common";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "wouter";
 import { useFileUpload } from "@/hooks/useFileUpload";
 import { genders, maritalStatuses } from "@shared/constants";
 
@@ -216,12 +216,13 @@ export const CandidateProfileEdit: React.FC = () => {
     <div className="max-w-4xl mx-auto">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center space-x-3">
-          <Link href="/candidate/dashboard">
-            <Button variant="ghost" size="sm" className="hover:bg-accent">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Go to Dashboard
-            </Button>
-          </Link>
+          <BackButton
+            fallback="/candidate/profile"
+            variant="ghost"
+            size="sm"
+            className="hover:bg-accent"
+            label="Back to Profile"
+          />
           <div>
             <h1 className="text-xl font-bold text-foreground">Profile Overview</h1>
             <p className="text-sm text-muted-foreground">View and edit your profile information section by section</p>

--- a/client/src/components/common/BackButton.tsx
+++ b/client/src/components/common/BackButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useLocation } from "wouter";
+import { Button, ButtonProps } from "@/components/ui/button";
+
+interface BackButtonProps extends ButtonProps {
+  fallback: string;
+  label?: string;
+}
+
+export const BackButton: React.FC<BackButtonProps> = ({
+  fallback,
+  label = "Back",
+  onClick,
+  ...props
+}) => {
+  const [, setLocation] = useLocation();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(e);
+    if (e.defaultPrevented) return;
+    if (window.history.state && window.history.state.idx > 0) {
+      window.history.back();
+    } else {
+      setLocation(fallback);
+    }
+  };
+
+  return (
+    <Button onClick={handleClick} {...props}>
+      <ArrowLeft className="h-4 w-4 mr-2" />
+      {label}
+    </Button>
+  );
+};

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export * from './Chatbot';
 export * from './Navbar';
 export * from './EntityCards';
+export * from './BackButton';

--- a/client/src/components/employer/EmployerJobCreate.tsx
+++ b/client/src/components/employer/EmployerJobCreate.tsx
@@ -21,7 +21,8 @@ import { useToast } from "@/hooks/use-toast";
 import { qualifications, experienceLevels } from "@shared/constants";
 import { useAuth } from "@/components/auth/AuthProvider";
 import { apiRequest } from "@/lib/queryClient";
-import { ArrowLeft, Briefcase, Plus, Minus } from "lucide-react";
+import { Briefcase, Plus, Minus } from "lucide-react";
+import { BackButton } from "@/components/common";
 import { jobPostValidationSchema } from "@shared/zod";
 import { z } from "zod";
 
@@ -198,18 +199,17 @@ export const EmployerJobCreate: React.FC = () => {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button
+        <BackButton
+          fallback="/jobs"
           variant="outline"
           size="sm"
+          label={referrer === 'jobs' ? 'Back to Jobs' : 'Back to Dashboard'}
+          className="border-border hover:bg-accent"
           onClick={() => {
             const targetPage = referrer === 'jobs' ? '/jobs' : '/employer/dashboard';
             setLocation(targetPage);
           }}
-          className="border-border hover:bg-accent"
-        >
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to {referrer === 'jobs' ? 'Jobs' : 'Dashboard'}
-        </Button>
+        />
         <div>
           <h1 className="text-3xl font-bold text-foreground">Create Job Post</h1>
           <p className="text-muted-foreground">Fill in the details to post a new job opening</p>

--- a/client/src/components/employer/EmployerJobEdit.tsx
+++ b/client/src/components/employer/EmployerJobEdit.tsx
@@ -12,7 +12,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { ArrowLeft, Save } from "lucide-react";
+import { Save } from "lucide-react";
+import { BackButton } from "@/components/common";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -145,10 +146,7 @@ export const EmployerJobEdit: React.FC = () => {
             <p className="text-muted-foreground mb-6">
               The job you're trying to edit doesn't exist or has been removed.
             </p>
-            <Button onClick={() => setLocation("/jobs")}>
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Jobs
-            </Button>
+            <BackButton fallback="/jobs" label="Back to Jobs" />
           </CardContent>
         </Card>
       </div>
@@ -166,12 +164,9 @@ export const EmployerJobEdit: React.FC = () => {
               This job has been marked as fulfilled and cannot be edited. You can clone this job to create a new posting.
             </p>
             <div className="flex gap-4 justify-center">
-              <Button onClick={() => setLocation("/jobs")}>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back to Jobs
-              </Button>
-              <Button 
-                variant="outline" 
+              <BackButton fallback="/jobs" label="Back to Jobs" />
+              <Button
+                variant="outline"
                 onClick={() => {
                   // Clone job functionality would go here
                   setLocation("/jobs/create");
@@ -189,10 +184,7 @@ export const EmployerJobEdit: React.FC = () => {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button variant="outline" onClick={() => setLocation("/jobs")}>
-          <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Jobs
-        </Button>
+        <BackButton fallback="/jobs" label="Back to Jobs" variant="outline" />
         <div>
           <h1 className="text-3xl font-bold text-foreground">Edit Job</h1>
           <p className="text-muted-foreground">Update job details and requirements</p>

--- a/client/src/components/employer/JobDetails.tsx
+++ b/client/src/components/employer/JobDetails.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
-  ArrowLeft,
   MapPin,
   Calendar,
   Users,
@@ -36,6 +35,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { JobPost, Application } from "@shared/types";
 import { formatDistanceToNow } from "date-fns";
 import { useLocation } from "wouter";
+import { BackButton } from "@/components/common";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 
@@ -178,12 +178,7 @@ export const JobDetails: React.FC = () => {
             <p className="text-muted-foreground mb-6">
               The job you're looking for doesn't exist or has been removed.
             </p>
-            <Link href="/jobs">
-              <Button>
-                <ArrowLeft className="h-4 w-4 mr-2" />
-                Back to Jobs
-              </Button>
-            </Link>
+            <BackButton fallback="/jobs" label="Back to Jobs" />
           </CardContent>
         </Card>
       </div>
@@ -248,12 +243,7 @@ export const JobDetails: React.FC = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <Link href="/jobs">
-            <Button variant="outline" size="sm">
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Jobs
-            </Button>
-          </Link>
+          <BackButton fallback="/jobs" label="Back to Jobs" variant="outline" size="sm" />
           <div>
             <h1 className="text-3xl font-bold text-foreground">{job.title}</h1>
             <p className="text-muted-foreground">Job Code: {job.jobCode}</p>


### PR DESCRIPTION
## Summary
- add generic `BackButton` component for consistent navigation
- replace hardcoded back links in admin, employer, and candidate sections
- allow fallback routes for job, admin, employer profile and candidate profile pages

## Testing
- `npm run check` *(fails: TypeScript errors)*
- `npm test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb23403a0832a836fc7c62463f65c