### PR TITLE
Use relative URLs for document upload/download

### DIFF
--- a/client/src/lib/documentApi.ts
+++ b/client/src/lib/documentApi.ts
@@ -1,4 +1,3 @@
-import { API_BASE_URL } from '@/config/api';
 import { authService } from './auth';
 import { throwIfResNotOk } from './queryClient';
 
@@ -21,7 +20,7 @@ export async function uploadDocument(
   const base = uid
     ? `/api/admin/${userType}s/${uid}/documents`
     : `/api/${userType}s/documents`;
-  const res = await fetch(`${API_BASE_URL}${base}/${docType}`, {
+  const res = await fetch(`${base}/${docType}`, {
     method: 'POST',
     headers,
     body: formData,
@@ -36,7 +35,7 @@ export async function uploadCertificates(files: File[], uid?: string) {
   const formData = new FormData();
   files.forEach(f => formData.append('files', f));
   const base = uid ? `/api/admin/candidates/${uid}/documents` : '/api/candidates/documents';
-  const res = await fetch(`${API_BASE_URL}${base}/certificates`, {
+  const res = await fetch(`${base}/certificates`, {
     method: 'POST',
     headers,
     body: formData,
@@ -51,7 +50,7 @@ export async function listDocuments(userType: 'candidate' | 'employer', uid?: st
   const base = uid
     ? `/api/admin/${userType}s/${uid}/documents`
     : `/api/${userType}s/documents`;
-  const res = await fetch(`${API_BASE_URL}${base}`, {
+  const res = await fetch(`${base}`, {
     method: 'GET',
     headers,
     credentials: 'include',
@@ -70,7 +69,7 @@ export async function downloadDocument(
   const base = uid
     ? `/api/admin/${userType}s/${uid}/documents`
     : `/api/${userType}s/documents`;
-  const url = `${API_BASE_URL}${base}/${docType}?filename=${encodeURIComponent(filename)}`;
+  const url = `${base}/${docType}?filename=${encodeURIComponent(filename)}`;
   const res = await fetch(url, { headers, credentials: 'include' });
   await throwIfResNotOk(res);
   const blob = await res.blob();

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -2,8 +2,6 @@ import { QueryClient, QueryFunction } from "@tanstack/react-query";
 import { authService } from "./auth";
 
 // API configuration using Vite's import.meta.env
-// Uses API_BASE_URL from api.ts config
-import { API_BASE_URL } from '@/config/api';
 
 export async function throwIfResNotOk(res: Response) {
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- remove `API_BASE_URL` dependency from document API helper
- use relative URLs when uploading or listing documents
- drop unused `API_BASE_URL` import in queryClient

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7e7d046c832a90ed64afa780b26c