### PR TITLE
Fix admin document rendering

### DIFF
--- a/client/src/components/admin/AdminCandidateDetails.tsx
+++ b/client/src/components/admin/AdminCandidateDetails.tsx
@@ -132,8 +132,18 @@ export const AdminCandidateDetails: React.FC = () => {
           </CardHeader>
           <CardContent className="space-y-2">
             {Object.entries(candidate.documents).map(([key, value]) => {
-              try {
-                const doc = JSON.parse(value as unknown as string);
+              let doc: any = null;
+              if (typeof value === "string") {
+                try {
+                  doc = JSON.parse(value);
+                } catch {
+                  /* ignore */
+                }
+              } else if (value && typeof value === "object") {
+                doc = value;
+              }
+
+              if (doc && typeof doc === "object" && "filename" in doc) {
                 return (
                   <div key={key} className="flex items-center justify-between">
                     <span className="capitalize text-muted-foreground">{key}:</span>
@@ -141,18 +151,18 @@ export const AdminCandidateDetails: React.FC = () => {
                       href={`/api/admin/candidates/${id}/documents/${key}`}
                       className="text-primary hover:underline"
                     >
-                      Download {doc?.name || key}
+                      Download {doc.filename || key}
                     </a>
-                 </div>
-                );
-              } catch {
-                return (
-                  <div key={key} className="flex items-center justify-between">
-                    <span className="capitalize text-muted-foreground">{key}:</span>
-                    <span className="font-medium">{value as string}</span>
                   </div>
                 );
               }
+
+              return (
+                <div key={key} className="flex items-center justify-between">
+                  <span className="capitalize text-muted-foreground">{key}:</span>
+                  <span className="font-medium">{String(value)}</span>
+                </div>
+              );
             })}
           </CardContent>
         </Card>

--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -95,8 +95,18 @@ export const AdminEmployerDetails: React.FC = () => {
           </CardHeader>
           <CardContent className="space-y-2">
             {Object.entries(employer.documents).map(([key, value]) => {
-              try {
-                const doc = JSON.parse(value as unknown as string);
+              let doc: any = null;
+              if (typeof value === "string") {
+                try {
+                  doc = JSON.parse(value);
+                } catch {
+                  /* ignore */
+                }
+              } else if (value && typeof value === "object") {
+                doc = value;
+              }
+
+              if (doc && typeof doc === "object" && "filename" in doc) {
                 return (
                   <div key={key} className="flex items-center justify-between">
                     <span className="capitalize text-muted-foreground">{key}:</span>
@@ -104,18 +114,18 @@ export const AdminEmployerDetails: React.FC = () => {
                       href={`/api/admin/employers/${id}/documents/${key}`}
                       className="text-primary hover:underline"
                     >
-                      Download {doc?.name || key}
+                      Download {doc.filename || key}
                     </a>
                   </div>
                 );
-              } catch {
-                return (
-                  <div key={key} className="flex items-center justify-between">
-                    <span className="capitalize text-muted-foreground">{key}:</span>
-                    <span className="font-medium">{value as string}</span>
-                  </div>
-                );
               }
+
+              return (
+                <div key={key} className="flex items-center justify-between">
+                  <span className="capitalize text-muted-foreground">{key}:</span>
+                  <span className="font-medium">{String(value)}</span>
+                </div>
+              );
             })}
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- handle objects in admin employer and candidate document lists to prevent React errors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8ddf08f0832a9bc368cf49d567a4