### PR TITLE
Enhance admin document sections

### DIFF
--- a/client/src/components/admin/AdminCandidateDetails.tsx
+++ b/client/src/components/admin/AdminCandidateDetails.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { User, Briefcase } from "lucide-react";
 import { BackButton } from "@/components/common";
+import { DocumentList } from "@/components/common/DocumentList";
 
 export const AdminCandidateDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -130,40 +131,25 @@ export const AdminCandidateDetails: React.FC = () => {
               Documents
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2">
-            {Object.entries(candidate.documents).map(([key, value]) => {
-              let doc: any = null;
-              if (typeof value === "string") {
-                try {
-                  doc = JSON.parse(value);
-                } catch {
-                  /* ignore */
-                }
-              } else if (value && typeof value === "object") {
-                doc = value;
-              }
-
-              if (doc && typeof doc === "object" && "filename" in doc) {
-                return (
-                  <div key={key} className="flex items-center justify-between">
-                    <span className="capitalize text-muted-foreground">{key}:</span>
-                    <a
-                      href={`/api/admin/candidates/${id}/documents/${key}`}
-                      className="text-primary hover:underline"
-                    >
-                      Download {doc.filename || key}
-                    </a>
-                  </div>
-                );
-              }
-
-              return (
-                <div key={key} className="flex items-center justify-between">
-                  <span className="capitalize text-muted-foreground">{key}:</span>
-                  <span className="font-medium">{String(value)}</span>
-                </div>
-              );
-            })}
+          <CardContent>
+            <DocumentList
+              docs={Object.entries(candidate.documents)
+                .map(([key, value]) => {
+                  let doc: any = null;
+                  if (typeof value === "string") {
+                    try { doc = JSON.parse(value); } catch {}
+                  } else if (value && typeof value === "object") {
+                    doc = value;
+                  }
+                  if (doc && typeof doc === "object" && "filename" in doc) {
+                    return { type: key, filename: doc.filename, uploadedAt: doc.uploadedAt || "" };
+                  }
+                  return null;
+                })
+                .filter(Boolean) as any}
+              baseUrl={`/api/admin/candidates/${id}/documents`}
+              hideFilename
+            />
           </CardContent>
         </Card>
       )}

--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Building2 } from "lucide-react";
 import { BackButton } from "@/components/common";
+import { DocumentList } from "@/components/common/DocumentList";
 
 export const AdminEmployerDetails: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -93,40 +94,25 @@ export const AdminEmployerDetails: React.FC = () => {
               Documents
             </CardTitle>
           </CardHeader>
-          <CardContent className="space-y-2">
-            {Object.entries(employer.documents).map(([key, value]) => {
-              let doc: any = null;
-              if (typeof value === "string") {
-                try {
-                  doc = JSON.parse(value);
-                } catch {
-                  /* ignore */
-                }
-              } else if (value && typeof value === "object") {
-                doc = value;
-              }
-
-              if (doc && typeof doc === "object" && "filename" in doc) {
-                return (
-                  <div key={key} className="flex items-center justify-between">
-                    <span className="capitalize text-muted-foreground">{key}:</span>
-                    <a
-                      href={`/api/admin/employers/${id}/documents/${key}`}
-                      className="text-primary hover:underline"
-                    >
-                      Download {doc.filename || key}
-                    </a>
-                  </div>
-                );
-              }
-
-              return (
-                <div key={key} className="flex items-center justify-between">
-                  <span className="capitalize text-muted-foreground">{key}:</span>
-                  <span className="font-medium">{String(value)}</span>
-                </div>
-              );
-            })}
+          <CardContent>
+            <DocumentList
+              docs={Object.entries(employer.documents)
+                .map(([key, value]) => {
+                  let doc: any = null;
+                  if (typeof value === "string") {
+                    try { doc = JSON.parse(value); } catch {}
+                  } else if (value && typeof value === "object") {
+                    doc = value;
+                  }
+                  if (doc && typeof doc === "object" && "filename" in doc) {
+                    return { type: key, filename: doc.filename, uploadedAt: doc.uploadedAt || "" };
+                  }
+                  return null;
+                })
+                .filter(Boolean) as any}
+              baseUrl={`/api/admin/employers/${id}/documents`}
+              hideFilename
+            />
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- add configurable options to `DocumentList`
- show admin candidate/employer documents using `DocumentList`

## Testing
- `npm test` *(fails: No test files found)*
- `npm run check` *(fails: TS errors during type check)*

------
https://chatgpt.com/codex/tasks/task_e_685e95e1fea8832a93229a7513887088