### PR TITLE
Fix admin document download

### DIFF
--- a/client/src/components/admin/AdminCandidateDetails.tsx
+++ b/client/src/components/admin/AdminCandidateDetails.tsx
@@ -147,7 +147,8 @@ export const AdminCandidateDetails: React.FC = () => {
                   return null;
                 })
                 .filter(Boolean) as any}
-              baseUrl={`/api/admin/candidates/${id}/documents`}
+              userType="candidate"
+              uid={id}
               hideFilename
             />
           </CardContent>

--- a/client/src/components/admin/AdminEmployerDetails.tsx
+++ b/client/src/components/admin/AdminEmployerDetails.tsx
@@ -110,7 +110,8 @@ export const AdminEmployerDetails: React.FC = () => {
                   return null;
                 })
                 .filter(Boolean) as any}
-              baseUrl={`/api/admin/employers/${id}/documents`}
+              userType="employer"
+              uid={id}
               hideFilename
             />
           </CardContent>

--- a/client/src/components/common/DocumentList.tsx
+++ b/client/src/components/common/DocumentList.tsx
@@ -10,7 +10,6 @@ interface Props {
   userType?: 'candidate' | 'employer';
   docs: Doc[];
   uid?: string;
-  baseUrl?: string;
   hideFilename?: boolean;
 }
 
@@ -18,7 +17,6 @@ export const DocumentList: React.FC<Props> = ({
   userType,
   docs,
   uid,
-  baseUrl,
   hideFilename,
 }) => {
   const { toast } = useToast();
@@ -28,16 +26,7 @@ export const DocumentList: React.FC<Props> = ({
       let blob: Blob;
       let name: string = doc.filename;
 
-      if (baseUrl) {
-        const res = await fetch(`${baseUrl}/${doc.type}?filename=${encodeURIComponent(doc.filename)}`, {
-          credentials: 'include',
-        });
-        if (!res.ok) throw new Error('Unable to download document');
-        blob = await res.blob();
-        const disposition = res.headers.get('Content-Disposition') || '';
-        const match = disposition.match(/filename="?([^";]+)"?/);
-        if (match) name = match[1];
-      } else if (userType) {
+      if (userType) {
         const result = await downloadDocument(userType, doc.type, doc.filename, uid);
         blob = result.blob;
         name = result.name;


### PR DESCRIPTION
## Summary
- ensure Authorization header when admins download candidate/employer docs

## Testing
- `npm run check` *(fails: Type 'any[] | QueryResult<never>' must have a '[Symbol.iterator]()' method)*
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9e344ccc832aaa6fd7233d897555