### PR TITLE
Add email verification and Google login

### DIFF
--- a/client/src/lib/auth.ts
+++ b/client/src/lib/auth.ts
@@ -4,6 +4,10 @@ import {
   signInWithPhoneNumber,
   RecaptchaVerifier,
   ConfirmationResult,
+  GoogleAuthProvider,
+  signInWithPopup,
+  sendEmailVerification,
+  reload,
   signOut,
   onAuthStateChanged,
   User
@@ -28,6 +32,32 @@ export class AuthService {
       return result.user;
     } catch (error) {
       throw new Error(`Email sign-up failed: ${error}`);
+    }
+  }
+
+  async signInWithGoogle() {
+    try {
+      const provider = new GoogleAuthProvider();
+      const result = await signInWithPopup(auth, provider);
+      return result.user;
+    } catch (error) {
+      throw new Error(`Google sign-in failed: ${error}`);
+    }
+  }
+
+  async sendVerificationEmail(user: User) {
+    try {
+      await sendEmailVerification(user);
+    } catch (error) {
+      throw new Error(`Sending verification email failed: ${error}`);
+    }
+  }
+
+  async reloadUser(user: User) {
+    try {
+      await reload(user);
+    } catch (error) {
+      throw new Error(`Reload user failed: ${error}`);
     }
   }
 

--- a/server/middleware/authenticate.ts
+++ b/server/middleware/authenticate.ts
@@ -8,6 +8,9 @@ export async function authenticateUser(req: Request & { user?: any }, res: Respo
       return res.status(401).json({ message: 'No token provided' });
     }
     const decodedToken = await verifyFirebaseToken(token);
+    if (!decodedToken.email_verified) {
+      return res.status(403).json({ message: 'Email not verified' });
+    }
     (req as any).user = decodedToken;
     next();
   } catch (error) {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { insertUserSchema } from '@shared/zod';
+import { registerUserSchema } from '@shared/zod';
 import type { InsertUser } from '@shared/types';
 import { authenticateUser } from '../middleware/authenticate';
 import { asyncHandler } from '../utils/asyncHandler';
@@ -8,10 +8,10 @@ import { UserRepository, CandidateRepository, EmployerRepository } from '../repo
 
 export const authRouter = Router();
 
-authRouter.post('/register', 
-  validateBody(insertUserSchema),
+authRouter.post('/register',
+  validateBody(registerUserSchema),
   asyncHandler(async (req, res) => {
-    const userData = req.body as any;
+    const { password, ...userData } = req.body as any;
     
     const existingUserByUid = await UserRepository.findByFirebaseUid(userData.firebaseUid);
     if (existingUserByUid) {

--- a/shared/zod/auth.ts
+++ b/shared/zod/auth.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { insertUserSchema } from './users';
+
+export const registerUserSchema = insertUserSchema.extend({
+  password: z.string()
+    .min(8, 'Password must be at least 8 characters long')
+    .regex(/[a-z]/, 'Password must contain a lowercase letter')
+    .regex(/[A-Z]/, 'Password must contain an uppercase letter')
+    .regex(/[^A-Za-z0-9]/, 'Password must contain a special character'),
+  email: z.string().email('Invalid email address'),
+});

--- a/shared/zod/index.ts
+++ b/shared/zod/index.ts
@@ -6,3 +6,4 @@ export * from './applications';
 export * from './shortlists';
 export * from './adminInviteCodes';
 export * from './searchAnalytics';
+export * from './auth';


### PR DESCRIPTION
## Summary
- add register schema with password validation
- validate password and email on server
- enforce email verification in auth middleware
- add Google login and verification features on frontend
- provide password/email validation in registration flow

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_685edfb2e99c832a8f01132b2babc490